### PR TITLE
Change GTK_LIBRARIES to GTK2_LIBRARIES

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -19,7 +19,7 @@ add_definitions(-DHAVE_GTK)
 # Nodelet library
 add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nodelet.cpp src/nodelets/window_thread.cpp)
 target_link_libraries(image_view ${catkin_LIBRARIES}
-                                 ${GTK_LIBRARIES}
+                                 ${GTK2_LIBRARIES}
                                  ${OpenCV_LIBRARIES}
 )
 install(TARGETS image_view
@@ -41,7 +41,7 @@ target_link_libraries(disparity_view ${catkin_LIBRARIES}
 add_executable(stereo_view src/nodes/stereo_view.cpp)
 target_link_libraries(stereo_view ${Boost_LIBRARIES}
                                   ${catkin_LIBRARIES}
-                                  ${GTK_LIBRARIES}
+                                  ${GTK2_LIBRARIES}
                                   ${OpenCV_LIBRARIES}
 )
 


### PR DESCRIPTION
Not sure if this was a typo to begin with or not, but Fedora needs GTK2_LIBRARIES to compile. Ubuntu works fine with either GTK_LIBRARIES or GTK2_LIBRARIES.
