### PR TITLE
fixed Boost error on OSX

### DIFF
--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED)
 
 find_package(catkin REQUIRED camera_calibration_parsers cv_bridge dynamic_reconfigure image_geometry image_transport nodelet roscpp sensor_msgs)
 find_package(OpenCV REQUIRED)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/CropDecimate.cfg cfg/Debayer.cfg cfg/Rectify.cfg)
@@ -26,7 +27,7 @@ add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
                                 src/nodelets/edge_aware.cpp
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -40,7 +41,7 @@ install(FILES nodelet_plugins.xml
 
 # Standalone node
 add_executable(image_proc_exe src/nodes/image_proc.cpp)
-target_link_libraries(image_proc_exe ${PROJECT_NAME})
+target_link_libraries(image_proc_exe ${PROJECT_NAME}  ${Boost_LIBRARIES})
 SET_TARGET_PROPERTIES(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
 install(TARGETS image_proc_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -53,4 +54,4 @@ install(DIRECTORY launch
 
 # Tests
 catkin_add_gtest(image_proc_rostest test/rostest.cpp)
-target_link_libraries(image_proc_rostest ${catkin_LIBRARIES})
+target_link_libraries(image_proc_rostest ${catkin_LIBRARIES}  ${Boost_LIBRARIES})

--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -39,6 +39,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <image_proc/CropDecimateConfig.h>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 namespace image_proc {
 

--- a/image_proc/src/nodelets/debayer.cpp
+++ b/image_proc/src/nodelets/debayer.cpp
@@ -43,6 +43,7 @@
 #include "edge_aware.h"
 
 #include <boost/make_shared.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 #include <cv_bridge/cv_bridge.h>
 

--- a/image_proc/src/nodelets/rectify.cpp
+++ b/image_proc/src/nodelets/rectify.cpp
@@ -38,6 +38,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <dynamic_reconfigure/server.h>
 #include <image_proc/RectifyConfig.h>
+#include <boost/thread/lock_guard.hpp>
 
 namespace image_proc {
 

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(stereo_image_proc)
 
 find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/Disparity.cfg)

--- a/stereo_image_proc/src/nodelets/disparity.cpp
+++ b/stereo_image_proc/src/nodelets/disparity.cpp
@@ -49,6 +49,8 @@
 #include <stereo_image_proc/DisparityConfig.h>
 #include <dynamic_reconfigure/server.h>
 
+#include <boost/thread/lock_guard.hpp>
+
 namespace stereo_image_proc {
 
 using namespace sensor_msgs;

--- a/stereo_image_proc/src/nodelets/point_cloud.cpp
+++ b/stereo_image_proc/src/nodelets/point_cloud.cpp
@@ -45,6 +45,8 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/image_encodings.h>
 
+#include <boost/thread/lock_guard.hpp>
+
 namespace stereo_image_proc {
 
 using namespace sensor_msgs;

--- a/stereo_image_proc/src/nodelets/point_cloud2.cpp
+++ b/stereo_image_proc/src/nodelets/point_cloud2.cpp
@@ -45,6 +45,8 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/image_encodings.h>
 
+#include <boost/thread/lock_guard.hpp>
+
 namespace stereo_image_proc {
 
 using namespace sensor_msgs;


### PR DESCRIPTION
I just installed Groovy on OSX and there were compile errors with boost::lock_guard. These changes allowed the packages to compile so I could finish the install.
