### PR TITLE
Fix bc905fcd, include boost/version.hpp before using BOOST_VERSION macro

### DIFF
--- a/depth_image_proc/src/nodelets/disparity.cpp
+++ b/depth_image_proc/src/nodelets/disparity.cpp
@@ -31,6 +31,11 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
+#include <boost/version.hpp>
+#if ((BOOST_VERSION / 100) % 1000) >= 53
+#include <boost/thread/lock_guard.hpp>
+#endif
+
 #include <ros/ros.h>
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>

--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
@@ -31,6 +31,11 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
+#include <boost/version.hpp>
+#if ((BOOST_VERSION / 100) % 1000) >= 53
+#include <boost/thread/lock_guard.hpp>
+#endif
+
 #include <ros/ros.h>
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>

--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -31,8 +31,9 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>

--- a/image_proc/src/nodelets/debayer.cpp
+++ b/image_proc/src/nodelets/debayer.cpp
@@ -32,8 +32,9 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 #include <boost/make_shared.hpp>
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>

--- a/image_proc/src/nodelets/rectify.cpp
+++ b/image_proc/src/nodelets/rectify.cpp
@@ -31,8 +31,9 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>

--- a/stereo_image_proc/src/nodelets/disparity.cpp
+++ b/stereo_image_proc/src/nodelets/disparity.cpp
@@ -31,9 +31,9 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
-
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>

--- a/stereo_image_proc/src/nodelets/point_cloud.cpp
+++ b/stereo_image_proc/src/nodelets/point_cloud.cpp
@@ -31,9 +31,9 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
-
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>

--- a/stereo_image_proc/src/nodelets/point_cloud2.cpp
+++ b/stereo_image_proc/src/nodelets/point_cloud2.cpp
@@ -31,9 +31,9 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
-
+#include <boost/version.hpp>
 #if ((BOOST_VERSION / 100) % 1000) >= 53
-#include <boost/thread/lock_guard.hpp>  
+#include <boost/thread/lock_guard.hpp>
 #endif
 
 #include <ros/ros.h>


### PR DESCRIPTION
The old commit uses the BOOST_VERSION macro before it is defined, hence the boost/thread/lock_guard.hpp never gets included, leading to the same compile errors which the commit is supposed to fix.

Also, some files in depth_image_proc needed the same fix.
