### PR TITLE
Fix an error which manifested after upgrading to boost 1.54

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -4,7 +4,7 @@ project(image_view)
 find_package(catkin REQUIRED)
 catkin_package()
 
-find_package(Boost COMPONENTS signals)
+find_package(Boost REQUIRED COMPONENTS signals thread)
 find_package(GTK2)
 find_package(OpenCV)
 find_package(catkin REQUIRED camera_calibration_parsers cv_bridge image_transport message_filters nodelet rosconsole roscpp)
@@ -22,6 +22,7 @@ target_link_libraries(image_view ${catkin_LIBRARIES}
                                  ${GTK_LIBRARIES}
                                  ${GTK2_LIBRARIES}
                                  ${OpenCV_LIBRARIES}
+                                 ${Boost_LIBRARIES}
 )
 install(TARGETS image_view
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/image_view/src/nodelets/window_thread.cpp
+++ b/image_view/src/nodelets/window_thread.cpp
@@ -40,7 +40,7 @@ namespace image_view {
 void startWindowThread()
 {
   static boost::once_flag cv_thread_flag = BOOST_ONCE_INIT;
-  boost::call_once(cv_thread_flag, &cv::startWindowThread);
+  boost::call_once(&cv::startWindowThread, cv_thread_flag);
 }
 
 } // namespace image_view


### PR DESCRIPTION
When building hydro most recently I got:

```
==> Processing catkin package: 'image_view'
==> Building with env: '/Users/william/hydro/install_isolated/env.sh'
==> cmake /Users/william/hydro/src/image_view -DCATKIN_DEVEL_PREFIX=/Users/william/hydro/devel_isolated/image_view -DCMAKE_INSTALL_PREFIX=/Users/william/hydro/install_isolated in '/Users/william/hydro/build_isolated/image_view'
-- Using CATKIN_DEVEL_PREFIX: /Users/william/hydro/devel_isolated/image_view
-- Using CMAKE_PREFIX_PATH: /Users/william/hydro/install_isolated
-- This workspace overlays: /Users/william/hydro/install_isolated
-- Using default Python package layout
-- Using CATKIN_ENABLE_TESTING: ON
-- Using CATKIN_TEST_RESULTS_DIR: /Users/william/hydro/build_isolated/image_view/test_results
-- Found gtest: gtests will be built
-- catkin 0.5.70
-- Boost version: 1.54.0
-- Found the following Boost libraries:
--   signals
--   system
--   thread
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/william/hydro/build_isolated/image_view
==> make -j1 in '/Users/william/hydro/build_isolated/image_view'
[ 12%] Built target disparity_view
[ 25%] Built target extract_images
[ 37%] Built target image_saver
Linking CXX shared library /Users/william/hydro/devel_isolated/image_view/lib/libimage_view.dylib
Undefined symbols for architecture x86_64:
  "boost::detail::once_epoch_cv", referenced from:
      void boost::call_once<int (*)()>(boost::once_flag&, int (*)()) in window_thread.cpp.o
  "boost::detail::once_epoch_mutex", referenced from:
      void boost::call_once<int (*)()>(boost::once_flag&, int (*)()) in window_thread.cpp.o
  "boost::detail::once_global_epoch", referenced from:
      void boost::call_once<int (*)()>(boost::once_flag&, int (*)()) in window_thread.cpp.o
  "boost::detail::get_once_per_thread_epoch()", referenced from:
      void boost::call_once<int (*)()>(boost::once_flag&, int (*)()) in window_thread.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/hydro/devel_isolated/image_view/lib/libimage_view.dylib] Error 1
make[1]: *** [CMakeFiles/image_view.dir/all] Error 2
make: *** [all] Error 2
<== Failed to process package 'image_view':
  Command '/Users/william/hydro/install_isolated/env.sh make -j1' returned non-zero exit status 2

Reproduce this error by running:
==> cd /Users/william/hydro/build_isolated && /Users/william/hydro/install_isolated/env.sh make -j1

Command failed, exiting.
```

I did some digging and couldn't really find anything, but then I found the documentation for `boost::call_once` on 1.32 and realized that image_view is using it wrong (at least according to that documentation, I can't even find the documentation for newer versions):

http://www.boost.org/doc/libs/1_32_0/doc/html/call_once.html

The first parameter is the callback and the second is the flag, so changing the code to do this instead fixed the problem. I'm sure this showed up as a linkedit problem because of fancy template magic in the headers...

I also find_packaged the threading component, as it is used and added REQUIRED, since it should stop if Boost isn't found...

Someone should test this on Linux before merging, because honestly I don't really understand why it worked at all before...

Another alternative would be to implement this in a more sane way... I'm not sure what that way would be, but I feel like it could be simplified.
