### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/camera_calibration/CMakeLists.txt
+++ b/camera_calibration/CMakeLists.txt
@@ -6,19 +6,20 @@ catkin_package()
 
 catkin_python_setup()
 
-# Unit test of calibrator.py
-catkin_add_nosetests(test/directed.py)
+if(CATKIN_ENABLE_TESTING)
+  # Unit test of calibrator.py
+  catkin_add_nosetests(test/directed.py)
 
-# Unit test of the approximate synchronizer
-catkin_add_nosetests(test/testapproxsync.py)
+  # Unit test of the approximate synchronizer
+  catkin_add_nosetests(test/testapproxsync.py)
 
-# Tests simple calibration dataset
-catkin_download_test_data(camera_calibration.tar.gz http://download.ros.org/data/camera_calibration/camera_calibration.tar.gz MD5 6da43ea314640a4c15dd7a90cbc3aee0)
+  # Tests simple calibration dataset
+  catkin_download_test_data(camera_calibration.tar.gz http://download.ros.org/data/camera_calibration/camera_calibration.tar.gz MD5 6da43ea314640a4c15dd7a90cbc3aee0)
 
-# Tests multiple checkerboards
-catkin_download_test_data(multi_board_calibration.tar.gz http://download.ros.org/data/camera_calibration/multi_board_calibration.tar.gz MD5 ddc0f69582d140e33f9d3bfb681956bb)
-catkin_add_nosetests(test/multiple_boards.py)
-
+  # Tests multiple checkerboards
+  catkin_download_test_data(multi_board_calibration.tar.gz http://download.ros.org/data/camera_calibration/multi_board_calibration.tar.gz MD5 ddc0f69582d140e33f9d3bfb681956bb)
+  catkin_add_nosetests(test/multiple_boards.py)
+endif()
 
 install(PROGRAMS nodes/camera_calibrate_from_disk.py 
                  nodes/cameracalibrator.py

--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -9,7 +9,7 @@
   <author>Patrick Mihelich</author>
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <test_depend>rostest</test_depend>
 

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -54,6 +54,8 @@ install(DIRECTORY launch
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/
 )
 
-# Tests
-catkin_add_gtest(image_proc_rostest test/rostest.cpp)
-target_link_libraries(image_proc_rostest ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
+if(CATKIN_ENABLE_TESTING)
+  # Tests
+  catkin_add_gtest(image_proc_rostest test/rostest.cpp)
+  target_link_libraries(image_proc_rostest ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
+endif()

--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -13,7 +13,7 @@
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <test_depend>rostest</test_depend>
   


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
