### PR TITLE
Improvements in calibration from tarfile

### DIFF
--- a/camera_calibration/scripts/tarfile_calibration.py
+++ b/camera_calibration/scripts/tarfile_calibration.py
@@ -49,10 +49,10 @@ import rospy
 import sensor_msgs.srv
 
 def waitkey():
-   k = cv.WaitKey(6)
-   if k in [27, ord('q')]:
-      rospy.signal_shutdown('Quit')
-   return k
+    k = cv.WaitKey(6)
+    if k in [27, ord('q')]:
+        rospy.signal_shutdown('Quit')
+    return k
 
 def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags = 0, alpha=1.0):
     if mono:
@@ -86,7 +86,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
 
     archive = tarfile.open(tarname, 'r')
     if mono:
-       for f in archive.getnames():
+        for f in archive.getnames():
             if f.startswith('left') and (f.endswith('.pgm') or f.endswith('png')):
                 filedata = archive.extractfile(f).read()
                 file_bytes = numpy.asarray(bytearray(filedata), dtype=numpy.uint8)
@@ -106,7 +106,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                 cv2.imshow( f,  numpy.asarray( drawable.scrib[:,:] ))
                 k=-1;
                 while k ==-1:
-                  k=waitkey();
+                    k=waitkey();
                 cv2.destroyWindow(f) 
     else:
         limages = [ f for f in archive.getnames() if (f.startswith('left') and (f.endswith('pgm') or f.endswith('png'))) ]
@@ -126,7 +126,6 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                 filedata = archive.extractfile(l).read()
                 file_bytes = numpy.asarray(bytearray(filedata), dtype=numpy.uint8)
                 im_left=cv2.imdecode(file_bytes,cv2.cv.CV_LOAD_IMAGE_COLOR)
-                im_left_rect=calibrator.l.remap(cv.fromarray(im_left));
    
                 bridge = cv_bridge.CvBridge()
                 try:
@@ -154,7 +153,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                 cv2.imshow( l+" "+r,  vis)
                 k=-1
                 while k ==-1:
-                  k=waitkey();
+                    k=waitkey();
                 cv2.destroyWindow( l+" "+r)
 
 if __name__ == '__main__':

--- a/camera_calibration/scripts/tarfile_calibration.py
+++ b/camera_calibration/scripts/tarfile_calibration.py
@@ -49,8 +49,6 @@ import sensor_msgs.srv
 
 def waitkey():
     k = cv2.waitKey(6)
-    if k in [27, ord('q')]:
-        rospy.signal_shutdown('Quit')
     return k
 
 def display(win_name, img):
@@ -59,7 +57,10 @@ def display(win_name, img):
     k=-1
     while k ==-1:
         k=waitkey()
-    cv2.destroyWindow(win_name) 
+    cv2.destroyWindow(win_name)
+    if k in [27, ord('q')]:
+        rospy.signal_shutdown('Quit')
+
 
 def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags = 0, visualize = False, alpha=1.0):
     if mono:
@@ -91,7 +92,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
     if visualize:
 
         #Show rectified images
-        calibrator.set_alpha(alpha);
+        calibrator.set_alpha(alpha)
 
         archive = tarfile.open(tarname, 'r')
         if mono:
@@ -116,14 +117,14 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
             limages = [ f for f in archive.getnames() if (f.startswith('left') and (f.endswith('pgm') or f.endswith('png'))) ]
             limages.sort()
             rimages = [ f for f in archive.getnames() if (f.startswith('right') and (f.endswith('pgm') or f.endswith('png'))) ]
-            rimages.sort();
+            rimages.sort()
 
             if not len(limages) == len(rimages):
                 raise RuntimeError("Left, right images don't match. %d left images, %d right" % (len(limages), len(rimages)))
             
             for i in range(len(limages)):
-                l=limages[i];
-                r=rimages[i];
+                l=limages[i]
+                r=rimages[i]
 
                 if l.startswith('left') and (l.endswith('.pgm') or l.endswith('png')) and r.startswith('right') and (r.endswith('.pgm') or r.endswith('png')):
                     # LEFT IMAGE
@@ -146,14 +147,14 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                     except cv_bridge.CvBridgeError, e:
                         print e
 
-                    drawable=calibrator.handle_msg([ msg_left,msg_right] );
+                    drawable=calibrator.handle_msg([ msg_left,msg_right] )
 
                     h, w = numpy.asarray(drawable.lscrib[:,:]).shape[:2]
                     vis = numpy.zeros((h, w*2, 3), numpy.uint8)
                     vis[:h, :w ,:] = numpy.asarray(drawable.lscrib[:,:])
                     vis[:h, w:w*2, :] = numpy.asarray(drawable.rscrib[:,:])
                     
-                    display(l+" "+r,vis);    
+                    display(l+" "+r,vis)    
 
 
 if __name__ == '__main__':

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -559,6 +559,7 @@ class MonoCalibrator(Calibrator):
         """
         goodcorners = self.collect_corners(images)
         self.cal_fromcorners(goodcorners)
+        self.calibrated = True
 
     def collect_corners(self, images):
         """
@@ -857,6 +858,7 @@ class StereoCalibrator(Calibrator):
         self.l.size = self.size
         self.r.size = self.size
         self.cal_fromcorners(goodcorners)
+        self.calibrated = True
 
     def collect_corners(self, limages, rimages):
         """


### PR DESCRIPTION
Improved the script to calibrate from a tarfile:
1- Added possibility to set different calibration flags: number of coefficients, fix ratio, set zero tangent coeffs.
  This would help users to try different calibration settings with the same images, so he can get the bests results without spending as much time as before (bagging, replaying bag, changing parameters)
2- Rectified images and corners detected displayed after calibration.
  This would help users to see quickly if the calibration was successful and furthermore check if corner detection failed in some images and remove it from the dataset for further calibrations.

Tested with mono and stereo datasets.
