### PR TITLE
Added OpenCV libraries to linking.

### DIFF
--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
                                 src/nodelets/edge_aware.cpp
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}  ${Boost_LIBRARIES}
+  ${OpenCV_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
I found that if the system OpenCV differs from OpenCV specified using `OpenCV_DIR` I had to add this to the CMake file to avoid linking errors.
