### PR TITLE
Added requirement for core.

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_package()
 
 find_package(Boost REQUIRED COMPONENTS signals thread)
 find_package(GTK2)
-find_package(OpenCV REQUIRED highgui)
+find_package(OpenCV REQUIRED highgui core)
 find_package(catkin REQUIRED camera_calibration_parsers cv_bridge image_transport message_filters nodelet rosconsole roscpp)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS}
                            ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
I also required this line in order to successfully compile with a non-system opencv 2.4.8. Otherwise, I had linking errors.
