### PR TITLE
Image rotate using tf2

### DIFF
--- a/image_rotate/CMakeLists.txt
+++ b/image_rotate/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(image_rotate)
 
-find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure image_transport roscpp tf nodelet)
+find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure image_transport roscpp tf nodelet eigen_conversions tf_conversions)
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(cfg/ImageRotate.cfg)

--- a/image_rotate/cfg/ImageRotate.cfg
+++ b/image_rotate/cfg/ImageRotate.cfg
@@ -51,7 +51,7 @@ gen.add("output_frame_id", str_t, 0, "Frame to publish for the image's new orien
 gen.add("input_frame_id", str_t, 0, "Frame to use for the original camera image. Empty means that the frame in the image or camera_info should be used depending on use_camera_info.", "")
 
 gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
-
+gen.add("use_tf2", bool_t, 0, "Use tf2 to lookup transformation", False)
 gen.add("max_angular_rate", double_t, 0, "Limits the rate at which the image can rotate (rad/s). Zero means no limit.", 10, 0, 100)
 
 gen.add("output_image_size", double_t, 0, "Size of the output image as a function of the input image size. Can be varied continuously between the following special settings: 0 ensures no black ever appears, 1 is small image dimension, 2 is large image dimension, 3 is image diagonal.", 2, 0, 3)

--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -37,7 +37,10 @@
   <build_depend>opencv2</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>nodelet</build_depend>
+  <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf_conversions</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
@@ -45,7 +48,10 @@
   <run_depend>opencv2</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>nodelet</run_depend>
+  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf_conversions</run_depend>
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
   </export>

--- a/image_rotate/src/nodelet/image_rotate_nodelet.cpp
+++ b/image_rotate/src/nodelet/image_rotate_nodelet.cpp
@@ -137,7 +137,6 @@ class ImageRotateNodelet : public nodelet::Nodelet
                        const ros::Duration& duration)
   {
     if (use_tf2_) {
-      NODELET_INFO("lookup %s -> %s", input_frame_id.c_str(), source_frame_id.c_str());
       geometry_msgs::TransformStamped trans
         = tf2_client_->lookupTransform(input_frame_id, source_frame_id,
                                        target_time, duration);
@@ -172,11 +171,6 @@ class ImageRotateNodelet : public nodelet::Nodelet
       target_vector_.stamp_ = msg->header.stamp;
       target_vector_.frame_id_ = frameWithDefault(config_.target_frame_id, input_frame_id);
       tf::Stamped<tf::Vector3> target_vector_transformed;
-      // tf_sub_->waitForTransform(input_frame_id, msg->header.stamp,
-      //                           target_vector_.frame_id_, target_vector_.stamp_,
-      //                           input_frame_id, ros::Duration(0.2));
-      // tf_sub_->transformVector(input_frame_id, msg->header.stamp, target_vector_,
-      //                          input_frame_id, target_vector_transformed);
       transformVector(input_frame_id, msg->header.stamp,
                       target_vector_.frame_id_, target_vector_.stamp_,
                       input_frame_id, target_vector_, target_vector_transformed,
@@ -186,20 +180,15 @@ class ImageRotateNodelet : public nodelet::Nodelet
       source_vector_.stamp_ = msg->header.stamp;
       source_vector_.frame_id_ = frameWithDefault(config_.source_frame_id, input_frame_id);
       tf::Stamped<tf::Vector3> source_vector_transformed;
-      // tf_sub_->waitForTransform(input_frame_id, msg->header.stamp,
-      //                           source_vector_.frame_id_, source_vector_.stamp_,
-      //                           input_frame_id, ros::Duration(0.01));
-      // tf_sub_->transformVector(input_frame_id, msg->header.stamp, source_vector_,
-      //                          input_frame_id, source_vector_transformed);
       transformVector(input_frame_id, msg->header.stamp,
                       source_vector_.frame_id_, source_vector_.stamp_,
                       input_frame_id, source_vector_, source_vector_transformed,
                       ros::Duration(0.01));
 
-      //NODELET_INFO("target: %f %f %f", target_vector_.x(), target_vector_.y(), target_vector_.z());
-      //NODELET_INFO("target_transformed: %f %f %f", target_vector_transformed.x(), target_vector_transformed.y(), target_vector_transformed.z());
-      //NODELET_INFO("source: %f %f %f", source_vector_.x(), source_vector_.y(), source_vector_.z());
-      //NODELET_INFO("source_transformed: %f %f %f", source_vector_transformed.x(), source_vector_transformed.y(), source_vector_transformed.z());
+      // NODELET_INFO("target: %f %f %f", target_vector_.x(), target_vector_.y(), target_vector_.z());
+      // NODELET_INFO("target_transformed: %f %f %f", target_vector_transformed.x(), target_vector_transformed.y(), target_vector_transformed.z());
+      // NODELET_INFO("source: %f %f %f", source_vector_.x(), source_vector_.y(), source_vector_.z());
+      // NODELET_INFO("source_transformed: %f %f %f", source_vector_transformed.x(), source_vector_transformed.y(), source_vector_transformed.z());
 
       // Calculate the angle of the rotation.
       double angle = angle_;

--- a/image_rotate/src/nodelet/image_rotate_nodelet.cpp
+++ b/image_rotate/src/nodelet/image_rotate_nodelet.cpp
@@ -46,6 +46,9 @@
 
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
+#include <tf2_ros/buffer_client.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <tf_conversions/tf_eigen.h>
 #include <image_rotate/ImageRotateConfig.h>
 #include <geometry_msgs/Vector3Stamped.h>
 #include <image_transport/image_transport.h>
@@ -57,9 +60,10 @@
 namespace image_rotate {
 class ImageRotateNodelet : public nodelet::Nodelet
 {
-  tf::TransformListener tf_sub_;
+  bool use_tf2_;
+  boost::shared_ptr<tf::TransformListener> tf_sub_;
   tf::TransformBroadcaster tf_pub_;
-
+  boost::shared_ptr<tf2_ros::BufferClient> tf2_client_;
   image_rotate::ImageRotateConfig config_;
   dynamic_reconfigure::Server<image_rotate::ImageRotateConfig> srv;
 
@@ -77,6 +81,21 @@ class ImageRotateNodelet : public nodelet::Nodelet
   double angle_;
   ros::Time prev_stamp_;
 
+  void setupTFListener()
+  {
+    if (use_tf2_) {
+      // shutdown tf_sub_
+      if (tf_sub_) {
+        tf_sub_.reset();
+      }
+    }
+    else {
+      if(!tf_sub_) {
+        tf_sub_.reset(new tf::TransformListener());
+      }
+    }
+  }
+  
   void reconfigureCallback(image_rotate::ImageRotateConfig &new_config, uint32_t level)
   {
     config_ = new_config;
@@ -86,6 +105,10 @@ class ImageRotateNodelet : public nodelet::Nodelet
     { // @todo Could do this without an interruption at some point.
       unsubscribe();
       subscribe();
+    }
+    if (use_tf2_ != config_.use_tf2) {
+      use_tf2_ = config_.use_tf2;
+      setupTFListener();
     }
   }
 
@@ -106,6 +129,39 @@ class ImageRotateNodelet : public nodelet::Nodelet
     do_work(msg, msg->header.frame_id);
   }
 
+  void transformVector(const std::string& input_frame_id, const ros::Time& target_time,
+                       const std::string& source_frame_id, const ros::Time& time,
+                       const std::string& fixed_frame_id,
+                       const tf::Stamped<tf::Vector3>& input_vector,
+                       tf::Stamped<tf::Vector3>& target_vector,
+                       const ros::Duration& duration)
+  {
+    if (use_tf2_) {
+      NODELET_INFO("lookup %s -> %s", input_frame_id.c_str(), source_frame_id.c_str());
+      geometry_msgs::TransformStamped trans
+        = tf2_client_->lookupTransform(input_frame_id, source_frame_id,
+                                       target_time, duration);
+      // geometry_msgs -> eigen -> tf
+      Eigen::Affine3d transform_eigen;
+      tf::transformMsgToEigen(trans.transform, transform_eigen);
+      tf::StampedTransform transform_tf; // convert trans to tfStampedTransform
+      tf::transformEigenToTF(transform_eigen, transform_tf);
+      tf::Vector3 origin = tf::Vector3(0, 0, 0);
+      tf::Vector3 end = input_vector;
+      tf::Vector3 output = (transform_tf * end) - (transform_tf * origin);
+      target_vector.setData(output);
+      target_vector.stamp_ = input_vector.stamp_;
+      target_vector.frame_id_ = input_frame_id;
+    }
+    else {
+      tf_sub_->waitForTransform(input_frame_id, target_time,
+                                source_frame_id, time,
+                                fixed_frame_id, duration);
+      tf_sub_->transformVector(input_frame_id, target_time, input_vector,
+                               fixed_frame_id, target_vector);
+    }
+  }
+  
   void do_work(const sensor_msgs::ImageConstPtr& msg, const std::string input_frame_from_msg)
   {
     try
@@ -116,21 +172,29 @@ class ImageRotateNodelet : public nodelet::Nodelet
       target_vector_.stamp_ = msg->header.stamp;
       target_vector_.frame_id_ = frameWithDefault(config_.target_frame_id, input_frame_id);
       tf::Stamped<tf::Vector3> target_vector_transformed;
-      tf_sub_.waitForTransform(input_frame_id, msg->header.stamp,
-                               target_vector_.frame_id_, target_vector_.stamp_,
-                               input_frame_id, ros::Duration(0.2));
-      tf_sub_.transformVector(input_frame_id, msg->header.stamp, target_vector_,
-                              input_frame_id, target_vector_transformed);
+      // tf_sub_->waitForTransform(input_frame_id, msg->header.stamp,
+      //                           target_vector_.frame_id_, target_vector_.stamp_,
+      //                           input_frame_id, ros::Duration(0.2));
+      // tf_sub_->transformVector(input_frame_id, msg->header.stamp, target_vector_,
+      //                          input_frame_id, target_vector_transformed);
+      transformVector(input_frame_id, msg->header.stamp,
+                      target_vector_.frame_id_, target_vector_.stamp_,
+                      input_frame_id, target_vector_, target_vector_transformed,
+                      ros::Duration(0.2));
 
       // Transform the source vector into the image frame.
       source_vector_.stamp_ = msg->header.stamp;
       source_vector_.frame_id_ = frameWithDefault(config_.source_frame_id, input_frame_id);
       tf::Stamped<tf::Vector3> source_vector_transformed;
-      tf_sub_.waitForTransform(input_frame_id, msg->header.stamp,
-                               source_vector_.frame_id_, source_vector_.stamp_,
-                               input_frame_id, ros::Duration(0.01));
-      tf_sub_.transformVector(input_frame_id, msg->header.stamp, source_vector_,
-                              input_frame_id, source_vector_transformed);
+      // tf_sub_->waitForTransform(input_frame_id, msg->header.stamp,
+      //                           source_vector_.frame_id_, source_vector_.stamp_,
+      //                           input_frame_id, ros::Duration(0.01));
+      // tf_sub_->transformVector(input_frame_id, msg->header.stamp, source_vector_,
+      //                          input_frame_id, source_vector_transformed);
+      transformVector(input_frame_id, msg->header.stamp,
+                      source_vector_.frame_id_, source_vector_.stamp_,
+                      input_frame_id, source_vector_, source_vector_transformed,
+                      ros::Duration(0.01));
 
       //ROS_INFO("target: %f %f %f", target_vector_.x(), target_vector_.y(), target_vector_.z());
       //ROS_INFO("target_transformed: %f %f %f", target_vector_transformed.x(), target_vector_transformed.y(), target_vector_transformed.z());
@@ -259,6 +323,7 @@ public:
   {
     nh_ = getNodeHandle();
     it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
+    tf2_client_.reset(new tf2_ros::BufferClient("tf2_buffer_server", 100, ros::Duration(0.2)));
     subscriber_count_ = 0;
     angle_ = 0;
     prev_stamp_ = ros::Time(0, 0);


### PR DESCRIPTION
image_rotate subscribes /tf and building tf tree consumes CPU resources a lot.
this patch supports tf2 to decrease CPU consumption. 
- ~use_tf2 parameter to switch tf and tf2
