### PR TITLE
camera_calibration: Fix Python import order

### DIFF
--- a/camera_calibration/nodes/camera_calibrate_from_disk.py
+++ b/camera_calibration/nodes/camera_calibrate_from_disk.py
@@ -32,11 +32,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import os.path
 import sys
 import cv
 from camera_calibration.calibrator import MonoCalibrator, ChessboardInfo
-from __future__ import print_function
 
 def main(args):
   from optparse import OptionParser


### PR DESCRIPTION
Fixes this:

```
File "/opt/ros/hydro/lib/camera_calibration/camera_calibrate_from_disk.py", line 39
SyntaxError: from __future__ imports must occur at the beginning of the file
```

Please backport to Hydro. This is considered a syntax error and thus fails python bytecompiling while packaging for Fedora.
