### PR TITLE
depth_image_proc: fix missing symbols in nodelets

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED)
 catkin_package(LIBRARIES ${PROJECT_NAME})
 
 find_package(Boost REQUIRED)
-find_package(catkin REQUIRED cmake_modules cv_bridge image_geometry image_transport message_filters nodelet sensor_msgs stereo_msgs tf2)
+find_package(catkin REQUIRED cmake_modules cv_bridge eigen_conversions image_geometry image_transport message_filters nodelet sensor_msgs stereo_msgs tf2 tf2_ros)
 find_package(Eigen REQUIRED)
 include_directories(SYSTEM ${BOOST_INCLUDE_DIRS}
                            ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
Fixes several missing symbols I hit when running the openni2/rgbd pipeline. Tested under 14.04 and Indigo.
