### PR TITLE
image_view: Add depend on gtk2

### DIFF
--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -20,6 +20,7 @@
   
   <build_depend>camera_calibration_parsers</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>gtk2</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>libopencv-dev</build_depend>
   <build_depend>message_filters</build_depend>
@@ -32,6 +33,7 @@
 
   <run_depend>camera_calibration_parsers</run_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>gtk2</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>libopencv-dev</run_depend>
   <run_depend>message_filters</run_depend>


### PR DESCRIPTION
GTK2 headers are needed because of https://github.com/ros-perception/image_pipeline/blob/indigo/image_view/CMakeLists.txt#L8

The `rosdep` key `gtk` provides those headers: https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L747-L756

Thanks!
