### PR TITLE
Missing runtime dependency - eigen_conversions

### DIFF
--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -37,6 +37,7 @@
 
   <run_depend>boost</run_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>eigen_conversions</run_depend>
   <run_depend>image_geometry</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>nodelet</run_depend>


### PR DESCRIPTION
`libdepth_image_proc` is missing this dependency at runtime

```
> ldd libdepth_image_proc.so  | grep eigen
        libeigen_conversions.so => not found
```

Which causes the following error on loading depth_image_proc:

```
[ INFO] [1402564815.530736554]: /camera/rgb/camera_info -> /camera/rgb/camera_info
[ERROR] [1402564815.727176562]: Failed to load nodelet [/camera/depth_metric_rect] of type
 [depth_image_proc/convert_metric]: Failed to load library /opt/ros/indigo/lib//libdepth_image_proc.so.
 Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that
 names are consistent between this macro and your XML. Error string: Could not load library (Poco
 exception = libeigen_conversions.so: cannot open shared object file: No such file or directory)
[FATAL] [1402564815.727410623]: Service call failed!
```
