### PR TITLE
also print self.report() on calibrate ... allows to use the params witho...

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -808,7 +808,9 @@ class MonoCalibrator(Calibrator):
         self.size = cv.GetSize(self.db[0][1]) # TODO Needs to be set externally
         self.cal_fromcorners(self.good_corners)
         self.calibrated = True
-        print((self.ost())) # DEBUG
+        # DEBUG
+        print((self.report()))
+        print((self.ost()))
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """
@@ -1125,7 +1127,9 @@ class StereoCalibrator(Calibrator):
         self.r.size = self.size
         self.cal_fromcorners(self.good_corners)
         self.calibrated = True
-        print((self.ost())) # DEBUG
+        # DEBUG
+        print((self.report()))
+        print((self.ost()))
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """


### PR DESCRIPTION
...ut having to commit them (e.g. for extrensic calibration between to cameras not used as stereo pair)
