### PR TITLE
Fixes approximate time synchronization.

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -393,7 +393,7 @@ def main():
     if options.approximate == 0.0:
         sync = message_filters.TimeSynchronizer
     else:
-        sync = functools.partial(ApproximateTimeSynchronizer, options.approximate)
+        sync = functools.partial(ApproximateTimeSynchronizer, slop=options.approximate)
 
     num_ks = options.k_coefficients
 


### PR DESCRIPTION
When the approximate time synchronizer moved to
ros_comm/utilities/message_filters, the argument order was changed so
that the slop argument was moved to the end, breaking the use of
functools.partial to give it the same interface as the exact
synchronizer.
