### PR TITLE
flips width and height during resize to give correct aspect ratio in camera calibration

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -364,7 +364,7 @@ class Calibrator(object):
         width = img.shape[1]
         scale = math.sqrt( (width*height) / (640.*480.) )
         if scale > 1.0:
-            scrib = cv2.resize(img, (int(height / scale), int(width / scale)))
+            scrib = cv2.resize(img, (int(width / scale), int(height / scale)))
         else:
             scrib = img
         # Due to rounding, actual horizontal/vertical scaling may differ slightly


### PR DESCRIPTION
The width and height during image re-sizing seems to be reversed. See the ROS answers question here to see screenshots of a 1920x1080 image running: http://answers.ros.org/question/190725/camera-calibration-uses-wrong-aspect-ratio-from-usb-camera/

We are trying to calibrate a USB camera running at 1080p (i.e., 1920x1080). When launching `usb_cam` and then `image_view`, the image comes up correctly at the right aspect ration.

`rosrun usb_cam usb_cam_node _image_width:=1920 _image_height:=1080 _pixel_format:=yuyv rosrun image_view image_view image:=/usb_cam/image_raw`

![14085496818393553](https://cloud.githubusercontent.com/assets/954667/4044299/b52193a0-2d1e-11e4-8d4e-f5a5d9ae3624.png)

However, whenever we try and run the camera calibration node, the aspect ratio of the image seems to be reversed:

`rosrun camera_calibration cameracalibrator.py --size 8x6 --square 0.025 image:=/usb_cam/image_raw camera:=/usb_cam`

![14085498226286829](https://cloud.githubusercontent.com/assets/954667/4044308/d1a60830-2d1e-11e4-80a3-7993d79c4c4a.png)

We are running Ubuntu 14.04 64bit with the latest Indigo build.

Screen of calibrator after patch:

![screen](https://cloud.githubusercontent.com/assets/954667/3986901/e332d110-289f-11e4-9ce3-d7ec7eca40e2.png)
