### PR TITLE
add StereoSGBM and it can be chosen from dynamic_reconfigure

### DIFF
--- a/stereo_image_proc/cfg/Disparity.cfg
+++ b/stereo_image_proc/cfg/Disparity.cfg
@@ -8,6 +8,11 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+stereo_algo_enum = gen.enum([gen.const("StereoBM", int_t, 0, "Block Matching"),
+                               gen.const("StereoSGBM", int_t, 1, "SemiGlobal Block Matching")],
+                               "stereo algorithm")
+gen.add("stereo_algorithm", int_t, 0, "sterel algorithm", 0, 0, 1,
+        edit_method = stereo_algo_enum)
 # disparity block matching pre-filtering parameters
 gen.add("prefilter_size", int_t, 0, "Normalization window size, pixels", 9, 5, 255)
 gen.add("prefilter_cap",  int_t, 0, "Bound on normalized pixel values", 31, 1, 63)
@@ -15,7 +20,7 @@ gen.add("prefilter_cap",  int_t, 0, "Bound on normalized pixel values", 31, 1, 6
 # disparity block matching correlation parameters
 gen.add("correlation_window_size", int_t, 0, "SAD correlation window width, pixels", 15, 5, 255)
 gen.add("min_disparity",           int_t, 0, "Disparity to begin search at, pixels (may be negative)", 0, -128, 128)
-gen.add("disparity_range",         int_t, 0, "Number of disparities to search, pixels", 64, 32, 128)
+gen.add("disparity_range",         int_t, 0, "Number of disparities to search, pixels", 64, 32, 256)
 # TODO What about trySmallerWindows?
 
 # disparity block matching post-filtering parameters
@@ -24,7 +29,10 @@ gen.add("uniqueness_ratio",  double_t, 0, "Filter out if best match does not suf
 gen.add("texture_threshold", int_t,    0, "Filter out if SAD window response does not exceed texture threshold", 10, 0, 10000)
 gen.add("speckle_size",      int_t,    0, "Reject regions smaller than this size, pixels", 100, 0, 1000)
 gen.add("speckle_range",     int_t,    0, "Max allowed difference between detected disparities", 4, 0, 31)
-
+gen.add("fullDP", bool_t, 0, "Run the full variant of the algorithm, only available in SGBM", False)
+gen.add("P1", double_t, 0, "The first parameter controlling the disparity smoothness, only available in SGBM", 200, 0, 4000)
+gen.add("P2", double_t, 0, "The second parameter controlling the disparity smoothness., only available in SGBM", 400, 0, 4000)
+gen.add("disp12MaxDiff", int_t, 0, "Maximum allowed difference (in integer pixel units) in the left-right disparity check, only available in SGBM", 0, 0, 128)
 # First string value is node name, used only for generating documentation
 # Second string value ("Disparity") is name of class and generated
 #    .h file, with "Config" added, so class DisparityConfig


### PR DESCRIPTION
support `cv::StereoSGBM` in `stereo_image_proc/disparity`.
- add several parameters to dynamci_reconfigure parameters for StereoSGBM.
- the algorithm for stereo computation can be also chosen via dynamic_reconfigure

![screenshot_from_2014-08-25 18 32 13](https://cloud.githubusercontent.com/assets/40454/4028271/b25b6022-2c3a-11e4-96b3-06a092509a92.png)
