### PR TITLE
Update calibrator.py

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1012,7 +1012,7 @@ class StereoCalibrator(Calibrator):
 
             # Report epipolar error
             if lcorners is not None and rcorners is not None:
-                epierror = self.epipolar_error(lundistorted, rundistorted, lboard)
+                epierror = self.epipolar_error(lundistorted, rundistorted)
 
         else:
             lscrib = cv2.cvtColor(lscrib_mono, cv2.COLOR_GRAY2BGR)


### PR DESCRIPTION
bugfix: stereo calibrator crashed after the signature of the method for the computation of the epipolar error changed but the function call was not updated
