### PR TITLE
Change duplicated function name

### DIFF
--- a/image_view/src/nodes/stereo_view.cpp
+++ b/image_view/src/nodes/stereo_view.cpp
@@ -323,7 +323,7 @@ static unsigned char colormap[768] =
     255,  0, 0,
   };
 
-void increment(int* value)
+inline void increment(int* value)
 {
   ++(*value);
 }


### PR DESCRIPTION
When linking statically (in our case on Android) and because image_view is linked against image_transport, the increment function is duplicated (https://github.com/ros-perception/image_common/blob/483312b85671ec61e8aa15f96a52e0e493df53d2/image_transport/src/camera_subscriber.cpp#L41).

Is this the correct approach or would someone suggest to handle differently?
