### PR TITLE
Bound amount of memory used by camera calibration

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -372,7 +372,7 @@ def main():
                      type="string", default='narrow_stereo',
                      help="name of the camera to appear in the calibration file")
     parser.add_option("-Q", "--queue_size",
-                     type="int", default=0,
+                     type="int", default=30,
                      help="maximum size of the image queues to use (0 indicates infinite length queues)")
     group = OptionGroup(parser, "Chessboard Options",
                         "You must specify one or more chessboards as pairs of --size and --square options.")

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -373,7 +373,7 @@ def main():
                      help="name of the camera to appear in the calibration file")
     parser.add_option("-Q", "--queue_size",
                      type="int", default=0,
-                     help="maximum size of the image queues to use")
+                     help="maximum size of the image queues to use (0 indicates infinite length queues)")
     group = OptionGroup(parser, "Chessboard Options",
                         "You must specify one or more chessboards as pairs of --size and --square options.")
     group.add_option("-p", "--pattern",


### PR DESCRIPTION
Added the possibility to limit the size of the image queues in cameracalibrator.py. Should close #112.
