### PR TITLE
remove libopencv-dev and find_package(OpenCV)

### DIFF
--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -15,7 +15,6 @@
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_geometry</run_depend>
-  <run_depend>libopencv-dev</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_srvs</run_depend>

--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -9,12 +9,14 @@ catkin_package(
 
 find_package(Boost REQUIRED)
 find_package(Eigen REQUIRED)
-find_package(OpenCV)
 include_directories(include
         SYSTEM ${BOOST_INCLUDE_DIRS}
                ${catkin_INCLUDE_DIRS}
                ${EIGEN_INCLUDE_DIRS}
 )
+
+# set rpath
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_library(${PROJECT_NAME} src/nodelets/convert_metric.cpp
                              src/nodelets/disparity.cpp

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -4,7 +4,6 @@ project(image_proc)
 find_package(catkin REQUIRED)
 
 find_package(catkin REQUIRED cv_bridge dynamic_reconfigure image_geometry image_transport nodelet roscpp sensor_msgs)
-find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 # Dynamic reconfigure support
@@ -12,13 +11,15 @@ generate_dynamic_reconfigure_options(cfg/CropDecimate.cfg cfg/Debayer.cfg cfg/Re
 
 catkin_package(
   CATKIN_DEPENDS image_geometry roscpp sensor_msgs
-  DEPENDS OpenCV
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
 )
 
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
 include_directories(include)
+
+# set rpath
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Nodelet library
 add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
@@ -29,7 +30,7 @@ add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
                                 src/nodelets/edge_aware.cpp
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -41,9 +42,10 @@ install(FILES nodelet_plugins.xml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+
 # Standalone node
 add_executable(image_proc_exe src/nodes/image_proc.cpp)
-target_link_libraries(image_proc_exe ${PROJECT_NAME}  ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_proc_exe ${PROJECT_NAME}  ${Boost_LIBRARIES})
 SET_TARGET_PROPERTIES(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
 install(TARGETS image_proc_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -23,7 +23,6 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>image_geometry</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>libopencv-dev</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -32,7 +31,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>image_geometry</run_depend>
   <run_depend>image_transport</run_depend>
-  <run_depend>libopencv-dev</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/image_rotate/CMakeLists.txt
+++ b/image_rotate/CMakeLists.txt
@@ -8,17 +8,15 @@ generate_dynamic_reconfigure_options(cfg/ImageRotate.cfg)
 
 catkin_package()
 
-find_package(OpenCV REQUIRED core imgproc)
 find_package(Eigen REQUIRED)
 
 # add the executable
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
                            ${EIGEN_INCLUDE_DIRS}
-                           ${OpenCV_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} SHARED src/nodelet/image_rotate_nodelet.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS image_rotate
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -26,7 +24,7 @@ install(TARGETS image_rotate
 
 add_executable(image_rotate_exe src/node/image_rotate.cpp)
 SET_TARGET_PROPERTIES(image_rotate_exe PROPERTIES OUTPUT_NAME image_rotate)
-target_link_libraries(image_rotate_exe ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_rotate_exe ${catkin_LIBRARIES})
 
 install(TARGETS image_rotate_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -36,7 +36,6 @@
   <build_depend>eigen_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>libopencv-dev</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf2</build_depend>
@@ -46,7 +45,6 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>image_transport</run_depend>
-  <run_depend>libopencv-dev</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf2</run_depend>

--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -5,29 +5,24 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 find_package(Boost REQUIRED COMPONENTS signals thread)
-find_package(OpenCV REQUIRED)
 
 find_package(catkin REQUIRED camera_calibration_parsers cv_bridge image_transport message_filters nodelet rosconsole roscpp)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS}
                            ${catkin_INCLUDE_DIRS}
-                           ${OpenCV_INCLUDE_DIRS}
 )
+
+# set rpath
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Extra tools
 add_executable(extract_images src/nodes/extract_images.cpp)
-target_link_libraries(extract_images ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(extract_images ${catkin_LIBRARIES})
 
 add_executable(image_saver src/nodes/image_saver.cpp)
-target_link_libraries(image_saver ${catkin_LIBRARIES}
-                                  ${OpenCV_LIBRARIES}
-)
+target_link_libraries(image_saver ${catkin_LIBRARIES})
 
 add_executable(video_recorder src/nodes/video_recorder.cpp)
-target_link_libraries(video_recorder ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(video_recorder ${catkin_LIBRARIES})
 
 install(TARGETS extract_images image_saver video_recorder
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -47,7 +42,6 @@ add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nod
 target_link_libraries(image_view ${catkin_LIBRARIES}
                                  ${GTK_LIBRARIES}
                                  ${GTK2_LIBRARIES}
-                                 ${OpenCV_LIBRARIES}
                                  ${Boost_LIBRARIES}
 )
 install(TARGETS image_view
@@ -58,21 +52,17 @@ install(TARGETS image_view
 add_executable(image_view_exe src/nodes/image_view.cpp)
 SET_TARGET_PROPERTIES(image_view_exe PROPERTIES OUTPUT_NAME image_view)
 target_link_libraries(image_view_exe ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
                                      ${Boost_LIBRARIES}
 )
 
 add_executable(disparity_view src/nodes/disparity_view.cpp)
-target_link_libraries(disparity_view ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(disparity_view ${catkin_LIBRARIES})
 
 add_executable(stereo_view src/nodes/stereo_view.cpp)
 target_link_libraries(stereo_view ${Boost_LIBRARIES}
                                   ${catkin_LIBRARIES}
                                   ${GTK_LIBRARIES}
                                   ${GTK2_LIBRARIES}
-                                  ${OpenCV_LIBRARIES}
 )
 
 install(TARGETS disparity_view image_view_exe stereo_view

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -22,7 +22,6 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>gtk2</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>libopencv-dev</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>rosconsole</build_depend>
@@ -35,7 +34,6 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>gtk2</run_depend>
   <run_depend>image_transport</run_depend>
-  <run_depend>libopencv-dev</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>python-opencv</run_depend>

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -15,16 +15,15 @@ catkin_package(
 
 include_directories(include)
 
-find_package(OpenCV REQUIRED)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
-                           ${OpenCV_INCLUDE_DIRS}
-)
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
+
+# set rpath
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Nodelet library
 add_library(${PROJECT_NAME} src/libstereo_image_proc/processor.cpp src/nodelets/disparity.cpp src/nodelets/point_cloud2.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}
-                                      ${OpenCV_LIBRARIES}
-)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/stereo_image_proc/package.xml
+++ b/stereo_image_proc/package.xml
@@ -22,7 +22,6 @@
   <build_depend>image_geometry</build_depend>
   <build_depend>image_proc</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>libopencv-dev</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -33,7 +32,6 @@
   <run_depend>image_geometry</run_depend>
   <run_depend>image_proc</run_depend>
   <run_depend>image_transport</run_depend>
-  <run_depend>libopencv-dev</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
when we install ros-indigo-image-proc and try to compile cv_bridge against opencv3, image_proc in /opt/ros/indigo try to link cv_bridge in catkin_ws and that is linked against opencv3.

in this PR, we changed
- remove libopencv-dev from package.xml, depending on cv_bridge is ok
- if we depend on cv_bridge, we do not have to `find_package(OpenCV)` in each CMakeLists.txt
- add `SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)` , so /opt/ros/indigo/lib/libimage_proc.so uses cv_bridge in /opt/ros/indigo, not in catkin_ws, this may need discussion.

this pr requires https://github.com/ros-perception/vision_opencv/pull/105
