### PR TITLE
when no image is saved, do not save camera info

### DIFF
--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -122,6 +122,8 @@ private:
         ROS_INFO("Saved image %s", filename.c_str());
 
         save_image_service = false;
+      } else {
+        return false;
       }
     } else {
       ROS_WARN("Couldn't save image, no data!");


### PR DESCRIPTION
When the images are not recorded because "save_all_image" is false and "save_image_service" is false, the frame count should not be incremented and the camera info should not be written to disk.
