### PR TITLE
image_view freeze fix for OpenCV 3 installed from Source

### DIFF
--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -72,6 +72,7 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
   if (!g_last_image.empty()) {
     const cv::Mat &image = g_last_image;
     cv::imshow(g_window_name, image);
+    cv::waitKey(3);
   }
 }
 


### PR DESCRIPTION
image_view freezes when opencv is installed from source. 
Before fix:
![screenshot from 2016-03-09 15 28 33](https://cloud.githubusercontent.com/assets/9315167/13632943/acbabe32-e62f-11e5-8adf-973dd7c8614f.png)

After fix:
![screenshot from 2016-03-09 15 32 43](https://cloud.githubusercontent.com/assets/9315167/13632968/cafa6a28-e62f-11e5-82e1-8be5efc133c3.png)
