### PR TITLE
[camera_calbration] fix typo np -> numpy

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -248,9 +248,9 @@ class Calibrator(object):
             _, max_val, _, _ = cv2.minMaxLoc(img)
             if max_val > 0:
                 scale = 255.0 / max_val
-                mono_img = (img * scale).astype(np.uint8)
+                mono_img = (img * scale).astype(numpy.uint8)
             else:
-                mono_img = img.astype(np.uint8)
+                mono_img = img.astype(numpy.uint8)
             return mono_img
         else:
             return self.br.imgmsg_to_cv2(msg, "mono8")


### PR DESCRIPTION
`np` is note declared. Standardize into `np` -> `numpy`
