### PR TITLE
[image_view] Add colormap options for displaying image topic

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: ros-perception/vision_opencv
+    uri: https://github.com/ros-perception/vision_opencv.git
+    version: indigo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ dist: trusty
 language: generic
 env:
   - OPENCV_VERSION=2 ROS_DISTRO=indigo
+  - OPENCV_VERSION=2 ROS_DISTRO=indigo ROSINSTALL_FILE="$TRAVIS_BUILD_DIR/.travis.rosinstall"
   - OPENCV_VERSION=3 ROS_DISTRO=indigo
+  - OPENCV_VERSION=3 ROS_DISTRO=indigo ROSINSTALL_FILE="$TRAVIS_BUILD_DIR/.travis.rosinstall"
   - OPENCV_VERSION=2 ROS_DISTRO=jade
+  - OPENCV_VERSION=2 ROS_DISTRO=jade ROSINSTALL_FILE="$TRAVIS_BUILD_DIR/.travis.rosinstall"
   - OPENCV_VERSION=3 ROS_DISTRO=jade
+  - OPENCV_VERSION=3 ROS_DISTRO=jade ROSINSTALL_FILE="$TRAVIS_BUILD_DIR/.travis.rosinstall"
 # Version of 4 does not make sense but it's to pass the test below.
 # Disabled as Travis does not support Xenial
 #  - OPENCV_VERSION=4 ROS_DISTRO=kinetic
@@ -15,7 +19,6 @@ before_install:
   - export ROS_CI_DESKTOP=`lsb_release -cs`  # e.g. [precise|trusty]
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
-  - export ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
   - export CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
   - export ROS_PARALLEL_JOBS='-j8 -l6'
   # Install ROS

--- a/image_view/cfg/ImageView.cfg
+++ b/image_view/cfg/ImageView.cfg
@@ -5,6 +5,23 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+edit_method_colormap = gen.enum([
+    gen.const("NO_COLORMAP", int_t, -1, "NO_COLORMAP"),
+    gen.const("AUTUMN", int_t, 0, "COLORMAP_AUTUMN"),
+    gen.const("BONE", int_t, 1, "COLORMAP_BONE"),
+    gen.const("JET", int_t, 2, "COLORMAP_JET"),
+    gen.const("WINTER", int_t, 3, "COLORMAP_WINTER"),
+    gen.const("RAINBOW", int_t, 4, "COLORMAP_RAINBOW"),
+    gen.const("OCEAN", int_t, 5, "COLORMAP_OCEAN"),
+    gen.const("SUMMER", int_t, 6, "COLORMAP_SUMMER"),
+    gen.const("SPRING", int_t, 7, "COLORMAP_SPRING"),
+    gen.const("COOL", int_t, 8, "COLORMAP_COOL"),
+    gen.const("HSV", int_t, 9, "COLORMAP_HSV"),
+    gen.const("PINK", int_t, 10, "COLORMAP_PINK"),
+    gen.const("HOT", int_t, 11, "COLORMAP_HOT"),
+], "colormap")
+
 gen.add('do_dynamic_scaling', bool_t, 0, 'Do dynamic scaling about pixel values or not', False)
+gen.add('colormap', int_t, -1, "colormap", -1, -1, 11, edit_method=edit_method_colormap);
 
 exit(gen.generate(PACKAGE, 'image_view', 'ImageView'))

--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -162,7 +162,9 @@ void ImageNodelet::imageCb(const sensor_msgs::ImageConstPtr& msg)
 
   // Convert to OpenCV native BGR color
   try {
-    last_image_ = cvtColorForDisplay(cv_bridge::toCvShare(msg), "", do_dynamic_scaling)->image;
+    cv_bridge::CvtColorForDisplayOptions options;
+    options.do_dynamic_scaling = do_dynamic_scaling;
+    last_image_ = cvtColorForDisplay(cv_bridge::toCvShare(msg), "", options)->image;
   }
   catch (cv_bridge::Exception& e) {
     NODELET_ERROR_THROTTLE(30, "Unable to convert '%s' image for display: '%s'",

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -63,8 +63,10 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
 
   // Convert to OpenCV native BGR color
   try {
+    cv_bridge::CvtColorForDisplayOptions options;
+    options.do_dynamic_scaling = g_do_dynamic_scaling;
     g_last_image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(msg), "",
-                                                 g_do_dynamic_scaling)->image;
+                                                 options)->image;
   } catch (cv_bridge::Exception& e) {
     ROS_ERROR_THROTTLE(30, "Unable to convert '%s' image for display: '%s'",
                        msg->encoding.c_str(), e.what());

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -50,11 +50,13 @@ boost::format g_filename_format;
 boost::mutex g_image_mutex;
 std::string g_window_name;
 bool g_do_dynamic_scaling;
+int g_colormap;
 
 void reconfigureCb(image_view::ImageViewConfig &config, uint32_t level)
 {
   boost::mutex::scoped_lock lock(g_image_mutex);
   g_do_dynamic_scaling = config.do_dynamic_scaling;
+  g_colormap = config.colormap;
 }
 
 void imageCb(const sensor_msgs::ImageConstPtr& msg)
@@ -65,6 +67,7 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
   try {
     cv_bridge::CvtColorForDisplayOptions options;
     options.do_dynamic_scaling = g_do_dynamic_scaling;
+    options.colormap = g_colormap;
     g_last_image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(msg), "",
                                                  options)->image;
   } catch (cv_bridge::Exception& e) {

--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -72,7 +72,11 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::Ca
 
     try
     {
-      const cv::Mat image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(image_msg), encoding, use_dynamic_range, min_depth_range, max_depth_range)->image;
+      cv_bridge::CvtColorForDisplayOptions options;
+      options.do_dynamic_scaling = use_dynamic_range;
+      options.min_image_value = min_depth_range;
+      options.max_image_value = max_depth_range;
+      const cv::Mat image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(image_msg), encoding, options)->image;
       if (!image.empty()) {
         outputVideo << image;
         ROS_INFO_STREAM("Recording frame " << g_count << "\x1b[1F");


### PR DESCRIPTION
DependsOn ros-perception/vision_opencv#130
## Result

**Default** (flag value: -1)
<img src="https://cloud.githubusercontent.com/assets/4310419/15095076/86a6aca0-14f2-11e6-9914-7f9b453a5231.jpg" width="30%" />
**Autumn** (flag value: 0)
<img src="https://cloud.githubusercontent.com/assets/4310419/15095072/7609b6da-14f2-11e6-99a0-e08cf9c8f9f8.jpg" width="30%" />
**Rainbow** (flag value: 4)
<img src="https://cloud.githubusercontent.com/assets/4310419/15095073/760a3880-14f2-11e6-927f-9c85c3c3147a.jpg" width="30%" />

http://docs.opencv.org/2.4/modules/contrib/doc/facerec/colormaps.html
