### PR TITLE
[image_view] Get correct fps in video_recorder.cpp

### DIFF
--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -71,7 +71,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::Ca
     }
     else if (outputVideo.isOpened() && info) return;
 
-    if ((g_last_wrote_time != ros::Time(0)) && ((ros::Time::now() - g_last_wrote_time) < ros::Duration(1 / fps)))
+    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1 / fps))
     {
       // Skip to get video with correct fps
       return;

--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -30,6 +30,7 @@
 cv::VideoWriter outputVideo;
 
 int g_count = 0;
+ros::Time g_last_wrote_time = ros::Time(0);
 std::string encoding;
 std::string codec;
 int fps;
@@ -70,6 +71,12 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::Ca
     }
     else if (outputVideo.isOpened() && info) return;
 
+    if ((g_last_wrote_time != ros::Time(0)) && ((ros::Time::now() - g_last_wrote_time) < ros::Duration(1 / fps)))
+    {
+      // Skip to get video with correct fps
+      return;
+    }
+
     try
     {
       const cv::Mat image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(image_msg), encoding, use_dynamic_range, min_depth_range, max_depth_range)->image;
@@ -77,6 +84,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::Ca
         outputVideo << image;
         ROS_INFO_STREAM("Recording frame " << g_count << "\x1b[1F");
         g_count++;
+        g_last_wrote_time = image_msg->header.stamp;
       } else {
           ROS_WARN("Frame skipped, no data!");
       }


### PR DESCRIPTION
Close #207 

```
% date; rosrun image_view video_recorder image:=/left_hand_camera/depth/image _fps:=1; date
Fri Jul  8 23:16:32 JST 2016
[ INFO] [1467987393.530164658]: Waiting for topic /left_hand_camera/depth/image...
[ INFO] [1467987393.675201947]: Starting to record MJPG video at [640 x 480]@1fps. Press Ctrl+C to stop recording.
^CINFO] [1467987398.580576018]: Recording frame 5
Video saved as output.avi
Fri Jul  8 23:16:39 JST 2016
```
