### PR TITLE
launch image view with a predefined window size

### DIFF
--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -135,6 +135,18 @@ int main(int argc, char **argv)
   cv::namedWindow(g_window_name, autosize ? (CV_WINDOW_AUTOSIZE | CV_WINDOW_KEEPRATIO | CV_GUI_EXPANDED) : 0);
   cv::setMouseCallback(g_window_name, &mouseCb);
 
+  if(autosize == false)
+  {
+	  if(local_nh.hasParam("width") && local_nh.hasParam("height"))
+	  {
+		  int width;
+		  local_nh.getParam("width", width);
+		  int height;
+		  local_nh.getParam("height", height);
+		  cv::resizeWindow(g_window_name, width, height);
+	  }
+  }
+
   // Start the OpenCV window thread so we don't have to waitKey() somewhere
   cv::startWindowThread();
 


### PR DESCRIPTION
We came across a use case where we want to launch an image_view window with a predefined window size. The solution checks if autoscale is not set and introduces two new ROS parameters (width and height). If both are present the window is resized. This way, previous functionality is maintained and the window is only resized if you specifically tell the node to at launch time.
