### PR TITLE
Added an argument to the calibration script for user defined folder location.

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -43,6 +43,7 @@ from collections import deque
 import threading
 import functools
 import time
+import tempfile
 
 import cv2
 import numpy
@@ -95,7 +96,7 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', folder_location='/tmp/', checkerboard_flags = 0):
+                 pattern=Patterns.Chessboard, camera_name='', folder_location=tempfile.gettempdir(), checkerboard_flags = 0):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -279,9 +280,9 @@ class OpenCVCalibrationNode(CalibrationNode):
 
     def screendump(self, im):
         i = 0
-        while os.access("/tmp/dump%d.png" % i, os.R_OK):
+        while os.access(tempfile.gettempdir()+"/dump%d.png" % i, os.R_OK):
             i += 1
-        cv2.imwrite("/tmp/dump%d.png" % i, im)
+        cv2.imwrite(tempfile.gettempdir()+"/dump%d.png" % i, im)
 
     def redraw_monocular(self, drawable):
         height = drawable.scrib.shape[0]
@@ -362,11 +363,11 @@ def main():
     parser = OptionParser("%prog --size SIZE1 --square SQUARE1 [ --size SIZE2 --square SQUARE2 ]",
                           description=None)
     parser.add_option("-c", "--camera_name",
-                     type="string", default='narrow_stereo',
-                     help="name of the camera to appear in the calibration file")
+                      type="string", default='narrow_stereo',
+                      help="name of the camera to appear in the calibration file")
     parser.add_option("-f", "--folder_location",
-                     type="string", default='/tmp/',
-                     help="Location of the folder where to save the calibration files")
+                      type="string", default=tempfile.gettempdir(),
+                      help="Location of the folder where to save the calibration files")
     group = OptionGroup(parser, "Chessboard Options",
                         "You must specify one or more chessboards as pairs of --size and --square options.")
     group.add_option("-p", "--pattern",

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -55,7 +55,7 @@ class DisplayThread(threading.Thread):
     """
     Thread that displays the current images
     It is its own thread so that all display can be done
-    in one thread to overcome imshow limitations and 
+    in one thread to overcome imshow limitations and
     https://github.com/ros-perception/image_pipeline/issues/85
     """
     def __init__(self, queue, opencv_calibration_node):
@@ -95,7 +95,7 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0):
+                 pattern=Patterns.Chessboard, camera_name='', folder_location='/tmp/', checkerboard_flags = 0):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -115,6 +115,8 @@ class CalibrationNode:
         self._checkerboard_flags = checkerboard_flags
         self._pattern = pattern
         self._camera_name = camera_name
+        self._folder_location = folder_location
+
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)
@@ -122,7 +124,7 @@ class CalibrationNode:
 
         msub = message_filters.Subscriber('image', sensor_msgs.msg.Image)
         msub.registerCallback(self.queue_monocular)
-        
+
         self.set_camera_info_service = rospy.ServiceProxy("%s/set_camera_info" % rospy.remap_name("camera"),
                                                           sensor_msgs.srv.SetCameraInfo)
         self.set_left_camera_info_service = rospy.ServiceProxy("%s/set_camera_info" % rospy.remap_name("left_camera"),
@@ -142,7 +144,7 @@ class CalibrationNode:
         sth = ConsumerThread(self.q_stereo, self.handle_stereo)
         sth.setDaemon(True)
         sth.start()
-        
+
     def redraw_stereo(self, *args):
         pass
     def redraw_monocular(self, *args):
@@ -158,10 +160,10 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                        checkerboard_flags=self._checkerboard_flags)
+                                        folder_location=self._folder_location, checkerboard_flags=self._checkerboard_flags)
             else:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                        checkerboard_flags=self.checkerboard_flags)
+                                        folder_location=self._folder_location, checkerboard_flags=self.checkerboard_flags)
 
         # This should just call the MonoCalibrator
         drawable = self.c.handle_msg(msg)
@@ -172,16 +174,16 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          folder_location=self._folder_location, checkerboard_flags=self._checkerboard_flags)
             else:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          folder_location=self._folder_location, checkerboard_flags=self._checkerboard_flags)
 
         drawable = self.c.handle_msg(msg)
         self.displaywidth = drawable.lscrib.shape[1] + drawable.rscrib.shape[1]
         self.redraw_stereo(drawable)
-            
- 
+
+
     def check_set_camera_info(self, response):
         if response.success:
             return True
@@ -274,7 +276,7 @@ class OpenCVCalibrationNode(CalibrationNode):
     def y(self, i):
         """Set up right-size images"""
         return 30 + 40 * i
-        
+
     def screendump(self, im):
         i = 0
         while os.access("/tmp/dump%d.png" % i, os.R_OK):
@@ -362,6 +364,9 @@ def main():
     parser.add_option("-c", "--camera_name",
                      type="string", default='narrow_stereo',
                      help="name of the camera to appear in the calibration file")
+    parser.add_option("-f", "--folder_location",
+                     type="string", default='/tmp/',
+                     help="Location of the folder where to save the calibration files")
     group = OptionGroup(parser, "Chessboard Options",
                         "You must specify one or more chessboards as pairs of --size and --square options.")
     group.add_option("-p", "--pattern",
@@ -398,11 +403,11 @@ def main():
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     parser.add_option_group(group)
-    options, args = parser.parse_args()
+    (options, args) = parser.parse_args()
 
     if len(options.size) != len(options.square):
         parser.error("Number of size and square inputs must be the same!")
-    
+
     if not options.square:
         options.square.append("0.108")
         options.size.append("8x6")
@@ -456,7 +461,7 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
-                                 checkerboard_flags=checkerboard_flags)
+                                 options.folder_location, checkerboard_flags=checkerboard_flags)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -205,7 +205,7 @@ class Calibrator(object):
     Base class for calibration system
     """
     def __init__(self, boards, flags=0, pattern=Patterns.Chessboard, name='',
-                folder_location='', checkerboard_flags=cv2.CALIB_CB_FAST_CHECK):
+                 folder_location=tempfile.gettempdir(), checkerboard_flags=cv2.CALIB_CB_FAST_CHECK):
         # Ordering the dimensions for the different detectors is actually a minefield...
         if pattern == Patterns.Chessboard:
             # Make sure n_cols > n_rows to agree with OpenCV CB detector output
@@ -786,8 +786,8 @@ class MonoCalibrator(Calibrator):
         print((self.ost()))
 
     def do_yaml_save(self, folder_location):
-        yaml_file = file(folder_location + 'ost.yaml', 'w')
-        yaml.dump(self.yaml(), yaml_file)
+        with open(folder_location + '/ost.yaml', 'w') as yaml_file:
+            yaml.dump(self.yaml(), yaml_file)
         yaml_file.close()
 
     def do_tarfile_save(self, tf):

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -47,6 +47,7 @@ import sensor_msgs.msg
 import tarfile
 import time
 import tempfile
+import yaml
 from distutils.version import LooseVersion
 
 
@@ -496,6 +497,7 @@ class Calibrator(object):
         return calmessage
 
     def do_save(self):
+        self.do_yaml_save(self.folder_location)
         filename = self.folder_location + '/calibrationdata.tar.gz'
         tf = tarfile.open(filename, 'w:gz')
         self.do_tarfile_save(tf) # Must be overridden in subclasses
@@ -782,6 +784,11 @@ class MonoCalibrator(Calibrator):
         # DEBUG
         print((self.report()))
         print((self.ost()))
+
+    def do_yaml_save(self, folder_location):
+        yaml_file = file(folder_location + 'ost.yaml', 'w')
+        yaml.dump(self.yaml(), yaml_file)
+        yaml_file.close()
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """
@@ -1102,6 +1109,15 @@ class StereoCalibrator(Calibrator):
         # DEBUG
         print((self.report()))
         print((self.ost()))
+
+    def do_yaml_save(self, folder_location):
+        left_yaml_file = file(folder_location + '/left.yaml', 'w')
+        yaml.dump(self.yaml("/left", self.l), left_yaml_file)
+        left_yaml_file.close()
+
+        right_yaml_file = file(folder_location + '/right.yaml', 'w')
+        yaml.dump(self.yaml("/right", self.r), right_yaml_file)
+        right_yaml_file.close()
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -46,6 +46,7 @@ import random
 import sensor_msgs.msg
 import tarfile
 import time
+import tempfile
 from distutils.version import LooseVersion
 
 
@@ -552,7 +553,7 @@ class MonoCalibrator(Calibrator):
         if 'name' not in kwargs:
             kwargs['name'] = 'narrow_stereo/left'
         if 'folder_location' not in kwargs:
-            kwargs['folder_location'] = '/tmp/'
+            kwargs['folder_location'] = tempfile.gettempdir()
         super(MonoCalibrator, self).__init__(*args, **kwargs)
 
     def cal(self, images):
@@ -774,7 +775,7 @@ class MonoCalibrator(Calibrator):
         # Dump should only occur if user wants it
         if dump:
             pickle.dump((self.is_mono, self.size, self.good_corners),
-                        open("/tmp/camera_calibration_%08x.pickle" % random.getrandbits(32), "w"))
+                        open(tempfile.gettempdir()+"/camera_calibration_%08x.pickle" % random.getrandbits(32), "w"))
         self.size = (self.db[0][1].shape[1], self.db[0][1].shape[0]) # TODO Needs to be set externally
         self.cal_fromcorners(self.good_corners)
         self.calibrated = True
@@ -824,7 +825,7 @@ class StereoCalibrator(Calibrator):
         if 'name' not in kwargs:
             kwargs['name'] = 'narrow_stereo'
         if 'folder_location' not in kwargs:
-            kwargs['folder_location'] = '/tmp/'
+            kwargs['folder_location'] = tempfile.gettempdir()
         super(StereoCalibrator, self).__init__(*args, **kwargs)
         self.l = MonoCalibrator(*args, **kwargs)
         self.r = MonoCalibrator(*args, **kwargs)
@@ -1092,7 +1093,7 @@ class StereoCalibrator(Calibrator):
         # Dump should only occur if user wants it
         if dump:
             pickle.dump((self.is_mono, self.size, self.good_corners),
-                        open("/tmp/camera_calibration_%08x.pickle" % random.getrandbits(32), "w"))
+                        open(tempfile.gettempdir()+"/camera_calibration_%08x.pickle" % random.getrandbits(32), "w"))
         self.size = (self.db[0][1].shape[1], self.db[0][1].shape[0]) # TODO Needs to be set externally
         self.l.size = self.size
         self.r.size = self.size

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -788,7 +788,6 @@ class MonoCalibrator(Calibrator):
     def do_yaml_save(self, folder_location):
         with open(folder_location + '/ost.yaml', 'w') as yaml_file:
             yaml.dump(self.yaml(), yaml_file)
-        yaml_file.close()
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """
@@ -1111,13 +1110,9 @@ class StereoCalibrator(Calibrator):
         print((self.ost()))
 
     def do_yaml_save(self, folder_location):
-        left_yaml_file = file(folder_location + '/left.yaml', 'w')
-        yaml.dump(self.yaml("/left", self.l), left_yaml_file)
-        left_yaml_file.close()
-
-        right_yaml_file = file(folder_location + '/right.yaml', 'w')
-        yaml.dump(self.yaml("/right", self.r), right_yaml_file)
-        right_yaml_file.close()
+        with open(folder_location + '/left.yaml', 'w') as left_yaml_file, open(folder_location + '/right.yaml', 'w') as right_yaml_file:
+            yaml.dump(self.yaml("/left", self.l), left_yaml_file)
+            yaml.dump(self.yaml("/right", self.r), right_yaml_file)
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """


### PR DESCRIPTION
This PR enables the user of camera _calibration to save the calculated parameters to custom location using an argument. By default it goes to /tmp folder. 

The editor updated the files with indentation changes according to https://www.python.org/dev/peps/pep-0008/. Please let me know if you want them to be reverted to avoid confusion.