### PR TITLE
Fix #235 for kinetic

### DIFF
--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -90,8 +90,6 @@ static void mouseCb(int event, int x, int y, int flags, void* param)
     return;
   }
 
-  boost::mutex::scoped_lock lock(g_image_mutex);
-
   const cv::Mat &image = g_last_image;
 
   if (image.empty()) {

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -83,10 +83,10 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
 
 static void mouseCb(int event, int x, int y, int flags, void* param)
 {
-  if (event == cv::EVENT_LBUTTONDOWN) {
-    ROS_WARN_ONCE("Left-clicking no longer saves images. Right-click instead.");
+  if (event == cv::EVENT_RBUTTONDOWN) {
+    ROS_WARN_ONCE("Right-clicking no longer saves images. Left-click instead.");
     return;
-  } else if (event != cv::EVENT_RBUTTONDOWN) {
+  } else if (event != cv::EVENT_LBUTTONDOWN) {
     return;
   }
 


### PR DESCRIPTION
This is workaround for #235, my guess is that it locks `g_image_mutex` within `mouseCb`, which I think called from `waitKey` function in `imageCb` that also locks `g_imgae_mutex`, so that it tryied to lock mutex whcih is already locked within same thread.

on Kinetic, Right click seems to assigned to other function as the picture, so I think it's better to us Left click for this purpose.

![screenshot from 2016-11-18 15-43-03](https://cloud.githubusercontent.com/assets/493276/20421337/95654a10-ada6-11e6-813f-8fdae0e6bed1.png)

