### PR TITLE
Apply value scaling to depth/float image with specified/default min/max range

### DIFF
--- a/image_view/cfg/ImageView.cfg
+++ b/image_view/cfg/ImageView.cfg
@@ -22,6 +22,8 @@ edit_method_colormap = gen.enum([
 ], "colormap")
 
 gen.add('do_dynamic_scaling', bool_t, 0, 'Do dynamic scaling about pixel values or not', False)
-gen.add('colormap', int_t, -1, "colormap", -1, -1, 11, edit_method=edit_method_colormap);
+gen.add('colormap', int_t, 0, "colormap", -1, -1, 11, edit_method=edit_method_colormap);
+gen.add('min_image_value', double_t, 0, "Minimum image value for scaling depth/float image.", default=0, min=0);
+gen.add('max_image_value', double_t, 0, "Maximum image value for scaling depth/float image.", default=0, min=0);
 
 exit(gen.generate(PACKAGE, 'image_view', 'ImageView'))

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -51,12 +51,16 @@ boost::mutex g_image_mutex;
 std::string g_window_name;
 bool g_do_dynamic_scaling;
 int g_colormap;
+double g_min_image_value;
+double g_max_image_value;
 
 void reconfigureCb(image_view::ImageViewConfig &config, uint32_t level)
 {
   boost::mutex::scoped_lock lock(g_image_mutex);
   g_do_dynamic_scaling = config.do_dynamic_scaling;
   g_colormap = config.colormap;
+  g_min_image_value = config.min_image_value;
+  g_max_image_value = config.max_image_value;
 }
 
 void imageCb(const sensor_msgs::ImageConstPtr& msg)
@@ -68,6 +72,21 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
     cv_bridge::CvtColorForDisplayOptions options;
     options.do_dynamic_scaling = g_do_dynamic_scaling;
     options.colormap = g_colormap;
+    // Set min/max value for scaling to visualize depth/float image.
+    if (g_min_image_value == g_max_image_value) {
+      // Not specified by rosparam, then set default value.
+      // Because of current sensor limitation, we use 10m as default of max range of depth
+      // with consistency to the configuration in rqt_image_view.
+      options.min_image_value = 0;
+      if (msg->encoding == "32FC1") {
+        options.max_image_value = 10;  // 10 [m]
+      } else if (msg->encoding == "16UC1") {
+        options.max_image_value = 10 * 1000;  // 10 * 1000 [mm]
+      }
+    } else {
+      options.min_image_value = g_min_image_value;
+      options.max_image_value = g_max_image_value;
+    }
     g_last_image = cv_bridge::cvtColorForDisplay(cv_bridge::toCvShare(msg), "",
                                                  options)->image;
   } catch (cv_bridge::Exception& e) {


### PR DESCRIPTION
This is to visualize depth images without `_do_dynamic_scaling:=true` rosparam specification.

- 32FC1: we assume meter metric, and 10[m] as the max range.
- 16UC1: we assume milimeter metric, and 10 * 1000[mm] as the max range.