### PR TITLE
Fixed stereo calibration problem with chessboard with the same number of rows and cols

### DIFF
--- a/camera_calibration/scripts/tarfile_calibration.py
+++ b/camera_calibration/scripts/tarfile_calibration.py
@@ -98,7 +98,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                 if f.startswith('left') and (f.endswith('.pgm') or f.endswith('png')):
                     filedata = archive.extractfile(f).read()
                     file_bytes = numpy.asarray(bytearray(filedata), dtype=numpy.uint8)
-                    im=cv2.imdecode(file_bytes,cv2.CV_LOAD_IMAGE_COLOR)
+                    im=cv2.imdecode(file_bytes,cv2.IMREAD_COLOR)
 
                     bridge = cv_bridge.CvBridge()
                     try:
@@ -128,7 +128,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                     # LEFT IMAGE
                     filedata = archive.extractfile(l).read()
                     file_bytes = numpy.asarray(bytearray(filedata), dtype=numpy.uint8)
-                    im_left=cv2.imdecode(file_bytes,cv2.CV_LOAD_IMAGE_COLOR)
+                    im_left=cv2.imdecode(file_bytes,cv2.IMREAD_COLOR)
        
                     bridge = cv_bridge.CvBridge()
                     try:
@@ -139,7 +139,7 @@ def cal_from_tarfile(boards, tarname, mono = False, upload = False, calib_flags 
                     #RIGHT IMAGE
                     filedata = archive.extractfile(r).read()
                     file_bytes = numpy.asarray(bytearray(filedata), dtype=numpy.uint8)
-                    im_right=cv2.imdecode(file_bytes,cv2.CV_LOAD_IMAGE_COLOR)
+                    im_right=cv2.imdecode(file_bytes,cv2.IMREAD_COLOR)
                     try:
                         msg_right=bridge.cv2_to_imgmsg(im_right, "bgr8")
                     except cv_bridge.CvBridgeError as e:

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -154,8 +154,19 @@ def _get_corners(img, board, refine = True, checkerboard_flags=0):
         ok = False
 
     # Ensure that all corner-arrays are going from top to bottom.
-    if corners[0, 0, 1] > corners[-1, 0, 1]:
-        corners = numpy.copy(numpy.flipud(corners))
+    if board.n_rows!=board.n_cols:
+        if corners[0, 0, 1] > corners[-1, 0, 1]:
+            corners = numpy.copy(numpy.flipud(corners))
+    else:
+        direction_corners=(corners[-1]-corners[0])>=numpy.array([[0.0,0.0]])
+    
+        if not numpy.all(direction_corners):
+            if not numpy.any(direction_corners):
+                corners = numpy.copy(numpy.flipud(corners))
+            elif direction_corners[0][0]:
+                corners=numpy.rot90(corners.reshape(board.n_rows,board.n_cols,2)).reshape(board.n_cols*board.n_rows,1,2)
+            else:
+                corners=numpy.rot90(corners.reshape(board.n_rows,board.n_cols,2),3).reshape(board.n_cols*board.n_rows,1,2)
 
     if refine and ok:
         # Use a radius of half the minimum distance between corners. This should be large enough to snap to the


### PR DESCRIPTION
Related to https://github.com/ros-perception/image_pipeline/issues/140, the stereo calibration fails when the detection of the corners has a different order for left and right cameras. This was solved on Jan 2 for chessboard with ncols=nrows as can be seen in the issue, but the problem continued for the case ncols=nrows, where detection apart from inverted can be rotated 90 or -90 degrees.


1- Changed flags CV_LOAD_IMAGE_COLOR by IMREAD_COLOR to adapt to Opencv3.

2- Fixed stereo calibration problem with chessboard with the same number of rows and cols by rotating the corners to same direction.