### PR TITLE
Use BytesIO to save calibration.

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -32,10 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 import cv2
 import cv_bridge
 import image_geometry
@@ -786,7 +783,7 @@ class MonoCalibrator(Calibrator):
         """ Write images and calibration solution to a tarfile object """
 
         def taradd(name, buf):
-            s = StringIO(buf)
+            s = BytesIO(buf)
             ti = tarfile.TarInfo(name)
             ti.size = len(s.getvalue())
             ti.uname = 'calibrator'
@@ -796,8 +793,8 @@ class MonoCalibrator(Calibrator):
         ims = [("left-%04d.png" % i, im) for i,(_, im) in enumerate(self.db)]
         for (name, im) in ims:
             taradd(name, cv2.imencode(".png", im)[1].tostring())
-        taradd('ost.yaml', self.yaml())
-        taradd('ost.txt', self.ost())
+        taradd('ost.yaml', self.yaml().encode('utf-8'))
+        taradd('ost.txt', self.ost().encode('utf-8'))
 
     def do_tarfile_calibration(self, filename):
         archive = tarfile.open(filename, 'r')
@@ -1106,7 +1103,7 @@ class StereoCalibrator(Calibrator):
                [("right-%04d.png" % i, im) for i,(_, _, im) in enumerate(self.db)])
 
         def taradd(name, buf):
-            s = StringIO(buf)
+            s = BytesIO(buf)
             ti = tarfile.TarInfo(name)
             ti.size = len(s.getvalue())
             ti.uname = 'calibrator'
@@ -1115,9 +1112,9 @@ class StereoCalibrator(Calibrator):
 
         for (name, im) in ims:
             taradd(name, cv2.imencode(".png", im)[1].tostring())
-        taradd('left.yaml', self.yaml("/left", self.l))
-        taradd('right.yaml', self.yaml("/right", self.r))
-        taradd('ost.txt', self.ost())
+        taradd('left.yaml', self.yaml("/left", self.l).encode('utf-8'))
+        taradd('right.yaml', self.yaml("/right", self.r).encode('utf-8'))
+        taradd('ost.txt', self.ost().encode('utf-8'))
 
     def do_tarfile_calibration(self, filename):
         archive = tarfile.open(filename, 'r')


### PR DESCRIPTION
As discussed in https://github.com/ros-perception/image_pipeline/pull/247 :

The main issue was that StringIO was used to write an encoded image (as a sequence of bytes) and the yaml and text files (as a string). In python2, a bytes array or string array are the same thing, which is why StringIO was applicable. In python3 however they are two separate things (try to evaluate `bytes is str` in python2/3). Therefore, StringIO was giving an error when writing the image, since it was expecting a `str` but received a `bytesarray`. The solution I chose here was to write the yaml files as bytes too and use a BytesIO instead.