### PR TITLE
remove find_package(OpenCV), but to use cv_bridge

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -13,7 +13,6 @@ if(NOT EIGEN3_FOUND)
   find_package(Eigen REQUIRED)
   set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
 endif()
-find_package(OpenCV REQUIRED)
 include_directories(include ${BOOST_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/nodelets/convert_metric.cpp
@@ -26,7 +25,7 @@ add_library(${PROJECT_NAME} src/nodelets/convert_metric.cpp
                              src/nodelets/point_cloud_xyzi_radial.cpp
                              src/nodelets/register.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -4,20 +4,18 @@ project(image_proc)
 find_package(catkin REQUIRED)
 
 find_package(catkin REQUIRED cv_bridge dynamic_reconfigure image_geometry image_transport nodelet roscpp sensor_msgs)
-find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/CropDecimate.cfg cfg/Debayer.cfg cfg/Rectify.cfg)
 
 catkin_package(
-  CATKIN_DEPENDS image_geometry roscpp sensor_msgs
-  DEPENDS OpenCV
+  CATKIN_DEPENDS cv_bridge image_geometry roscpp sensor_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 # Nodelet library
 add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
@@ -29,7 +27,7 @@ add_library(${PROJECT_NAME} src/libimage_proc/processor.cpp
                                 src/nodelets/crop_non_zero.cpp
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -43,7 +41,7 @@ install(FILES nodelet_plugins.xml
 
 # Standalone node
 add_executable(image_proc_exe src/nodes/image_proc.cpp)
-target_link_libraries(image_proc_exe ${PROJECT_NAME}  ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_proc_exe ${PROJECT_NAME} ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
 SET_TARGET_PROPERTIES(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
 install(TARGETS image_proc_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -19,7 +19,7 @@ install(TARGETS image_publisher
 
 add_executable(image_publisher_exe src/node/image_publisher.cpp)
 SET_TARGET_PROPERTIES(image_publisher_exe PROPERTIES OUTPUT_NAME image_publisher)
-target_link_libraries(image_publisher_exe ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_publisher_exe ${catkin_LIBRARIES})
 
 install(TARGETS image_publisher_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_rotate/CMakeLists.txt
+++ b/image_rotate/CMakeLists.txt
@@ -8,13 +8,11 @@ generate_dynamic_reconfigure_options(cfg/ImageRotate.cfg)
 
 catkin_package()
 
-find_package(OpenCV REQUIRED core imgproc)
-
 # add the executable
-include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} SHARED src/nodelet/image_rotate_nodelet.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS image_rotate
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -22,7 +20,7 @@ install(TARGETS image_rotate
 
 add_executable(image_rotate_exe src/node/image_rotate.cpp)
 SET_TARGET_PROPERTIES(image_rotate_exe PROPERTIES OUTPUT_NAME image_rotate)
-target_link_libraries(image_rotate_exe ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_rotate_exe ${catkin_LIBRARIES})
 
 install(TARGETS image_rotate_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -6,28 +6,20 @@ generate_dynamic_reconfigure_options(cfg/ImageView.cfg)
 
 catkin_package(CATKIN_DEPENDS dynamic_reconfigure)
 find_package(Boost REQUIRED COMPONENTS signals thread)
-find_package(OpenCV REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
-                    ${OpenCV_INCLUDE_DIRS}
 )
 
 # Extra tools
 add_executable(extract_images src/nodes/extract_images.cpp)
-target_link_libraries(extract_images ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(extract_images ${catkin_LIBRARIES})
 
 add_executable(image_saver src/nodes/image_saver.cpp)
-target_link_libraries(image_saver ${catkin_LIBRARIES}
-                                  ${OpenCV_LIBRARIES}
-)
+target_link_libraries(image_saver ${catkin_LIBRARIES})
 
 add_executable(video_recorder src/nodes/video_recorder.cpp)
-target_link_libraries(video_recorder ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(video_recorder ${catkin_LIBRARIES})
 
 install(TARGETS extract_images image_saver video_recorder
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -47,7 +39,6 @@ add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nod
 target_link_libraries(image_view ${catkin_LIBRARIES}
                                  ${GTK_LIBRARIES}
                                  ${GTK2_LIBRARIES}
-                                 ${OpenCV_LIBRARIES}
                                  ${Boost_LIBRARIES}
 )
 install(TARGETS image_view
@@ -59,21 +50,17 @@ add_executable(image_view_exe src/nodes/image_view.cpp)
 add_dependencies(image_view_exe ${PROJECT_NAME}_gencfg)
 SET_TARGET_PROPERTIES(image_view_exe PROPERTIES OUTPUT_NAME image_view)
 target_link_libraries(image_view_exe ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
                                      ${Boost_LIBRARIES}
 )
 
 add_executable(disparity_view src/nodes/disparity_view.cpp)
-target_link_libraries(disparity_view ${catkin_LIBRARIES}
-                                     ${OpenCV_LIBRARIES}
-)
+target_link_libraries(disparity_view ${catkin_LIBRARIES})
 
 add_executable(stereo_view src/nodes/stereo_view.cpp)
 target_link_libraries(stereo_view ${Boost_LIBRARIES}
                                   ${catkin_LIBRARIES}
                                   ${GTK_LIBRARIES}
                                   ${GTK2_LIBRARIES}
-                                  ${OpenCV_LIBRARIES}
 )
 
 install(TARGETS disparity_view image_view_exe stereo_view

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -15,14 +15,11 @@ catkin_package(
 
 include_directories(include)
 
-find_package(OpenCV REQUIRED)
-include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS})
 
 # Nodelet library
 add_library(${PROJECT_NAME} src/libstereo_image_proc/processor.cpp src/nodelets/disparity.cpp src/nodelets/point_cloud2.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}
-                                      ${OpenCV_LIBRARIES}
-)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
if we install ros-indigo-opencv3 and compile this package, the executbale segfaults because cv_bridge is linked against cv2 but this node is linked against cv3