### PR TITLE
Added C++11 instruction to image_proc, stereo_image_proc and depth_image_proc CMakeLists

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(depth_image_proc)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED cmake_modules cv_bridge eigen_conversions image_geometry image_transport message_filters nodelet sensor_msgs stereo_msgs tf2 tf2_ros)
 
 catkin_package(

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(image_proc)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED)
 
 find_package(catkin REQUIRED cv_bridge dynamic_reconfigure image_geometry image_transport nodelet nodelet_topic_tools roscpp sensor_msgs)

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -4,6 +4,8 @@ project(stereo_image_proc)
 find_package(catkin REQUIRED cv_bridge dynamic_reconfigure image_geometry image_proc image_transport message_filters nodelet sensor_msgs stereo_msgs)
 find_package(Boost REQUIRED COMPONENTS thread)
 
+add_compile_options(-std=c++11)
+
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/Disparity.cfg)
 


### PR DESCRIPTION
The kinetic branch of image_geometry now requires C++ 11 to compile, due to the use of shared_ptrs. This causes image_proc, stereo_image_proc and depth_image_proc to fail to compile. This PR fixes this by requiring these packages to compile with C++ 11.

Linked to issue https://github.com/ros-perception/image_pipeline/issues/291