### PR TITLE
Opencv datatype deprecation fix

### DIFF
--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -120,7 +120,7 @@ template <typename T>
 void debayer2x2toBGR(const cv::Mat& src, cv::Mat& dst, int R, int G1, int G2, int B)
 {
   typedef cv::Vec<T, 3> DstPixel; // 8- or 16-bit BGR
-  dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
+  dst.create(src.rows / 2, src.cols / 2, cv::traits::Type<DstPixel>::value);
 
   int src_row_step = src.step1();
   int dst_row_step = dst.step1();

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -22,6 +22,9 @@ include_directories(include)
 find_package(OpenCV REQUIRED)
 include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
+# Temporary fix for DataType deprecation in OpenCV 3.3.1
+add_definitions(-DOPENCV_TRAITS_ENABLE_DEPRECATED)
+
 # Nodelet library
 add_library(${PROJECT_NAME} src/libstereo_image_proc/processor.cpp src/nodelets/disparity.cpp src/nodelets/point_cloud2.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}


### PR DESCRIPTION
In OpenCV 3.3.1, `cv::DataType::type` was deprecated, which broke `image_proc` and `stereo_image_proc`.

`image_proc` was easily fixed by migrating to the recommended `cv::traits::Type::value`. `stereo_image_proc`however, uses the `mat.hpp` which has not been updated to use `cv::traits::Type::value`. My fix for that is to add the `OPENCV_TRAITS_ENABLE_DEPRECATED`definition to the `CMakeLists.txt`, which is a temporary fix until OpenCV is fixed.