### PR TITLE
link libimage_publisher against OpenCV

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -8,10 +8,12 @@ generate_dynamic_reconfigure_options(cfg/ImagePublisher.cfg)
 
 catkin_package()
 
+find_package(OpenCV REQUIRED core videoio)
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} SHARED src/nodelet/image_publisher_nodelet.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS image_publisher
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
When compiling image_publisher, I got linker errors with symbols in the cv::VideoCapture namespace. Linking against OpenCV solved the problem.

My Setup: macOS 10.13 with OpenCV version 3.3.1.