### PR TITLE
Fix image proc launch

### DIFF
--- a/image_proc/launch/image_proc.launch
+++ b/image_proc/launch/image_proc.launch
@@ -22,18 +22,15 @@
   <!-- Debayered images -->
   <!-- TODO Arguments for debayer, interpolation methods? -->
   <node if="$(arg debayer)" pkg="nodelet" type="nodelet" name="debayer"
-        args="load image_proc/debayer $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)" />
+        args="load image_proc/debayer $(arg manager) $(arg bond)" respawn="$(arg respawn)" />
 
   <!-- Monochrome rectified image -->
   <node if="$(arg monochrome_rect)" pkg="nodelet" type="nodelet" name="rectify_mono"
-        args="load image_proc/rectify $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)" />
+        args="load image_proc/rectify $(arg manager) $(arg bond)" respawn="$(arg respawn)" />
 
   <!-- Color rectified image -->
   <node if="$(arg color_rect)" pkg="nodelet" type="nodelet" name="rectify_color"
-        args="load image_proc/rectify $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
+        args="load image_proc/rectify $(arg manager) $(arg bond)" respawn="$(arg respawn)">
     <remap from="image_mono" to="$(arg color_rect_in_topic)" />
     <remap from="image_rect" to="$(arg color_rect_out_topic)" />
   </node>

--- a/image_proc/launch/image_proc.launch
+++ b/image_proc/launch/image_proc.launch
@@ -2,9 +2,7 @@
 <!-- Launch in the camera namespace containing "image_raw" and "camera_info" -->
 <launch>
   <!-- Manager name must be globally qualified -->
-  <arg name="manager" /> 
-  <!-- Worker threads -->
-  <arg name="num_worker_threads" default="4"/>
+  <arg name="manager" />
 
   <arg name="respawn"               default="false" />
   <arg name="debayer"               default="true" />
@@ -20,17 +18,6 @@
 
   <arg     if="$(arg respawn)" name="bond" value="" />
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
-
-  <!-- Optionally launch manager in GDB, for debugging -->
-  <arg name="debug" default="false" />
-  <arg if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args" />
-  <arg unless="$(arg debug)" name="launch_prefix" value="" />
-
-  <!-- Nodelet manager -->
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager"
-        output="screen" launch-prefix="$(arg launch_prefix)">
-     <param name="num_worker_threads" value="$(arg num_worker_threads)" />
-  </node>
 
   <!-- Debayered images -->
   <!-- TODO Arguments for debayer, interpolation methods? -->


### PR DESCRIPTION
This fixes `image_proc.launch` after https://github.com/ros-perception/image_pipeline/pull/299, where the nodelet manager was added to the launch file. I guess it was added by mistake by @bikramak, causing existing code/launch files to fail.

In my case the failure is due to the nodelet manager being in a namespace:
``` bash
RLException: while processing /opt/clearpath/2.8devel/sdk/share/image_proc/launch/image_proc.launch:
Invalid <node> tag: node name cannot contain a namespace. 

Node xml is <node args="manager" launch-prefix="$(arg launch_prefix)" name="$(arg manager)" output="screen" pkg="nodelet" type="nodelet">
     <param name="num_worker_threads" value="$(arg num_worker_threads)"/>
  </node>
The traceback for the exception was written to the log file
```

But in general the main issue is that the manager is run from another launch file, so at the end it gets run twice.

I've also changed three lines with a `respawn` that were indented with a tab instead of spaces, but that actually fit in 120 columns; I assume this is the desired max number columns because there was one > 80 columns. If you want I can remove this from the PR though.

FYI @vrabaud