### PR TITLE
Feature/calibrate fisheye

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -913,11 +913,6 @@ class StereoCalibrator(Calibrator):
         self.l.cal_fromcorners(lcorners)
         self.r.cal_fromcorners(rcorners)
 
-        #if numpy.any(numpy.isnan(self.l.intrinsics)) or numpy.any(numpy.isnan(self.r.intrinsics)):
-        print("Left:\n"+str(self.l.intrinsics)+"\n"+str(self.l.distortion)+"\n")
-        print("Right:\n"+str(self.r.intrinsics)+"\n"+str(self.r.distortion)+"\n")
-        #return False
-
         lipts = [ l for (l, _, _) in good ]
         ripts = [ r for (_, r, _) in good ]
         boards = [ b for (_, _, b) in good ]
@@ -927,7 +922,6 @@ class StereoCalibrator(Calibrator):
         self.T = numpy.zeros((3, 1), dtype=numpy.float64)
         self.R = numpy.eye(3, dtype=numpy.float64)
         if self.distortion_model == 'equidistant':
-            import pdb; pdb.set_trace()
             flags = cv2.fisheye.CALIB_FIX_INTRINSIC
             cv2.fisheye.stereoCalibrate(opts, lipts, ripts,
                                    self.l.intrinsics, self.l.distortion,

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -268,6 +268,11 @@ class Calibrator(object):
             else:
                 mono_img = img.astype(numpy.uint8)
             return mono_img
+        elif '8UC1' in msg.encoding:
+            # Equivalent to mono8
+            img = self.br.imgmsg_to_cv2(msg, "passthrough")
+            mono_img = img.astype(numpy.uint8)
+            return mono_img
         else:
             return self.br.imgmsg_to_cv2(msg, "mono8")
 

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -957,7 +957,6 @@ class StereoCalibrator(Calibrator):
                                    flags = flags)
 
         self.set_alpha(0.0)
-        return True
 
     def set_alpha(self, a):
         """
@@ -1167,13 +1166,8 @@ class StereoCalibrator(Calibrator):
         self.size = (self.db[0][1].shape[1], self.db[0][1].shape[0]) # TODO Needs to be set externally
         self.l.size = self.size
         self.r.size = self.size
-        if self.cal_fromcorners(self.good_corners):
-            self.calibrated = True
-            # DEBUG
-            print((self.report()))
-            print((self.ost()))
-        else:
-            print("Calibration failure. Collect more samples before trying again.")
+        self.cal_fromcorners(self.good_corners):
+        self.calibrated = True
 
     def do_tarfile_save(self, tf):
         """ Write images and calibration solution to a tarfile object """

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -655,7 +655,7 @@ class MonoCalibrator(Calibrator):
 
         if self.distortion_model == 'equidistant':
             ncm = cv2.fisheye.estimateNewCameraMatrixForUndistortRectify(
-                self.intrinsics, self.distortion, self.size, numpy.eye(3))
+                self.intrinsics, self.distortion, self.size, self.R, balance=1)
             for j in range(3):
                 for i in range(3):
                     self.P[j,i] = ncm[j, i]

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1166,7 +1166,7 @@ class StereoCalibrator(Calibrator):
         self.size = (self.db[0][1].shape[1], self.db[0][1].shape[0]) # TODO Needs to be set externally
         self.l.size = self.size
         self.r.size = self.size
-        self.cal_fromcorners(self.good_corners):
+        self.cal_fromcorners(self.good_corners)
         self.calibrated = True
 
     def do_tarfile_save(self, tf):

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -112,7 +112,6 @@ class CalibrationNode:
         self._pattern = pattern
         self._camera_name = camera_name
         self._distortion_model = distortion_model
-        print("Distortion Model: "+self._distortion_model)
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -91,8 +91,7 @@ class ConsumerThread(threading.Thread):
 
 
 class CalibrationNode:
-    def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0):
+    def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0, pattern=Patterns.Chessboard, camera_name='', distortion_model='', checkerboard_flags = 0):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -112,6 +111,8 @@ class CalibrationNode:
         self._checkerboard_flags = checkerboard_flags
         self._pattern = pattern
         self._camera_name = camera_name
+        self._distortion_model = distortion_model
+        print("Distortion Model: "+self._distortion_model)
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)
@@ -154,11 +155,9 @@ class CalibrationNode:
     def handle_monocular(self, msg):
         if self.c == None:
             if self._camera_name:
-                self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                        checkerboard_flags=self._checkerboard_flags)
+                self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name, distortion_model=self._distortion_model, checkerboard_flags=self._checkerboard_flags)
             else:
-                self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                        checkerboard_flags=self.checkerboard_flags)
+                self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, distortion_model=self._distortion_model, checkerboard_flags=self._checkerboard_flags)
 
         # This should just call the MonoCalibrator
         drawable = self.c.handle_msg(msg)
@@ -168,11 +167,10 @@ class CalibrationNode:
     def handle_stereo(self, msg):
         if self.c == None:
             if self._camera_name:
-                self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                          checkerboard_flags=self._checkerboard_flags)
+                self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name, distortion_model=self._distortion_model,  checkerboard_flags=self._checkerboard_flags)
             else:
-                self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                          checkerboard_flags=self._checkerboard_flags)
+                self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, distortion_model=self._distortion_model,
+                checkerboard_flags=self._checkerboard_flags)
 
         drawable = self.c.handle_msg(msg)
         self.displaywidth = drawable.lscrib.shape[1] + drawable.rscrib.shape[1]


### PR DESCRIPTION
I added some functionality to the camera_calibration package to allow the cameracalibrator.py utility to use OpenCV 3's fisheye module to model pinhole projection/equidistant distortion cameras.  Currently works well for all of the monocular cameras that I have available.  I also implemented something that "should work" for stereo pairs of fisheye cameras, but I did not have success for the stereo sensor that I had access to.  