### PR TITLE
Fixed bug in cv_bridge conversion - deal with 8UC1 encoding to mono8.

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -268,6 +268,11 @@ class Calibrator(object):
             else:
                 mono_img = img.astype(numpy.uint8)
             return mono_img
+        elif '8UC1' in msg.encoding:
+            # Equivalent to mono8
+            img = self.br.imgmsg_to_cv2(msg, "passthrough")
+            mono_img = img.astype(numpy.uint8)
+            return mono_img
         else:
             return self.br.imgmsg_to_cv2(msg, "mono8")
 


### PR DESCRIPTION
This came up when trying to calibrate one of the cameras on an Intel Realsense sensor.  The image was encoded as 8UC1, and cv_bridge complained about it not being a color format.  Forcing it to be interpreted as uint8 resolves this problem.