### PR TITLE
Removed unused mutable scratch buffers

### DIFF
--- a/stereo_image_proc/include/stereo_image_proc/processor.h
+++ b/stereo_image_proc/include/stereo_image_proc/processor.h
@@ -176,10 +176,6 @@ private:
   mutable cv::StereoSGBM sg_block_matcher_;
 #endif
   StereoType current_stereo_algorithm_;
-  // scratch buffers for speckle filtering
-  mutable cv::Mat_<uint32_t> labels_;
-  mutable cv::Mat_<uint32_t> wavefront_;
-  mutable cv::Mat_<uint8_t> region_types_;
   // scratch buffer for dense point cloud
   mutable cv::Mat_<cv::Vec3f> dense_points_;
 };


### PR DESCRIPTION
The uint32_t buffers conflicted with newer release of OpenCV3, as explained here https://github.com/ros-perception/image_pipeline/issues/310