### PR TITLE
fix 'VideoCapture' undefined symbol error

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -3,6 +3,16 @@ project(image_publisher)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure camera_info_manager sensor_msgs image_transport nodelet roscpp)
 
+find_package(OpenCV 3 REQUIRED
+  COMPONENTS
+    opencv_core
+    opencv_imgproc
+    opencv_imgcodecs
+    opencv_videoio
+    opencv_highgui
+  CONFIG
+)
+
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(cfg/ImagePublisher.cfg)
 
@@ -11,7 +21,7 @@ catkin_package()
 include_directories(${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} SHARED src/nodelet/image_publisher_nodelet.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 install(TARGETS image_publisher
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -19,7 +29,7 @@ install(TARGETS image_publisher
 
 add_executable(image_publisher_exe src/node/image_publisher.cpp)
 SET_TARGET_PROPERTIES(image_publisher_exe PROPERTIES OUTPUT_NAME image_publisher)
-target_link_libraries(image_publisher_exe ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(image_publisher_exe ${catkin_LIBRARIES})
 
 install(TARGETS image_publisher_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -3,15 +3,15 @@ project(image_publisher)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure camera_info_manager sensor_msgs image_transport nodelet roscpp)
 
-find_package(OpenCV 3 REQUIRED
-  COMPONENTS
-    opencv_core
-    opencv_imgproc
-    opencv_imgcodecs
-    opencv_videoio
-    opencv_highgui
-  CONFIG
-)
+set(opencv_2_components core highgui)
+set(opencv_3_components core imgcodecs videoio)
+find_package(OpenCV REQUIRED COMPONENTS core)
+message(STATUS "opencv version ${OpenCV_VERSION}")
+if(OpenCV_VERSION VERSION_LESS "3.0.0")
+  find_package(OpenCV 2 REQUIRED COMPONENTS ${opencv_2_components})  
+else()
+  find_package(OpenCV 3 REQUIRED COMPONENTS ${opencv_3_components})  
+endif()
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(cfg/ImagePublisher.cfg)


### PR DESCRIPTION
The following error occured when trying to run image_publisher:
[...]/devel/lib/image_publisher/image_publisher: symbol lookup error: [...]/devel/lib//libimage_publisher.so: undefined symbol: _ZN2cv12VideoCaptureC1Ev

Probably, changes in cv_bridge reducing the OpenCV component dependencies led to the error. See
https://github.com/ros-perception/vision_opencv/commit/8b5bbcbc1ce65734dc600695487909e0c67c1033

This is fixed by manually finding OpenCV with the required components and adding the dependencies to the library, not just the node.