### PR TITLE
camera_checker: Ensure cols + rows are in correct order

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -84,6 +84,10 @@ class CameraCheckerNode:
         self.board.n_rows = chess_size[1]
         self.board.dim = dim
 
+        # make sure n_cols is not smaller than n_rows, otherwise error computation will be off
+        if self.board.n_cols < self.board.n_rows:
+            self.board.n_cols, self.board.n_rows = self.board.n_rows, self.board.n_cols
+
         image_topic = rospy.resolve_name("monocular") + "/image_rect"
         camera_topic = rospy.resolve_name("monocular") + "/camera_info"
 


### PR DESCRIPTION
Without this pull request, specifying a smaller column than row size lead to
huge reported errors:

```
$ rosrun camera_calibration cameracheck.py --size 6x7 --square 0.0495
Linearity RMS Error: 13.545 Pixels      Reprojection RMS Error: 22.766 Pixels

$ rosrun camera_calibration cameracheck.py --size 7x6 --square 0.0495
Linearity RMS Error: 0.092 Pixels      Reprojection RMS Error: 0.083 Pixels
```

This pull request switches columns and rows around if necessary.

--------------------------------------------------

While debugging this, I plotted the errors in `MonoCalibrator.linear_error()`:

https://github.com/ros-perception/image_pipeline/blob/2c8a054ad1aff0acdac9af058812cf106e41a8e9/camera_calibration/src/camera_calibration/calibrator.py#L700-L725

I simply replaced line 721 by this and plotted it using gnuplot:

```diff --git
@@ -718,7 +720,9 @@ class MonoCalibrator(Calibrator):
             (x2, y2) = corners[(cc * r) + cc - 1, 0]
             for i in range(1, cc - 1):
                 (x0, y0) = corners[(cc * r) + i, 0]
-                errors.append(pt2line(x0, y0, x1, y1, x2, y2))
+                error = pt2line(x0, y0, x1, y1, x2, y2)
+                print x1, y1, x2, y2, x2-x1, y2-y1, x0, y0, error
+                errors.append(error)
         if errors:
             return math.sqrt(sum([e**2 for e in errors]) / len(errors))
         else:
```

These are the results with the `--size 6x7` flag without this pull request:
![results_6x7](https://user-images.githubusercontent.com/320188/36908884-e0c85c38-1e3c-11e8-8a0f-43ea4a54a483.png)

These are the results with the `--size 7x6` flag:
![results_7x6](https://user-images.githubusercontent.com/320188/36908926-fb433ed4-1e3c-11e8-8723-7c508d85cec4.png)

Clearly, when `n_cols < n_rows`, the array is indexed incorrectly and the errors are off. Same for the RMS error.