### PR TITLE
Add option to filter out close points from point cloud

### DIFF
--- a/depth_image_proc/include/depth_image_proc/depth_conversions.h
+++ b/depth_image_proc/include/depth_image_proc/depth_conversions.h
@@ -51,7 +51,8 @@ void convert(
     const sensor_msgs::ImageConstPtr& depth_msg,
     PointCloud::Ptr& cloud_msg,
     const image_geometry::PinholeCameraModel& model,
-    double range_max = 0.0)
+    double range_max = 0.0,
+    double range_min = 0.0)
 {
   // Use correct principal point from calibration
   float center_x = model.cx();
@@ -88,10 +89,17 @@ void convert(
         }
       }
 
-      // Fill in XYZ
-      *iter_x = (u - center_x) * depth * constant_x;
-      *iter_y = (v - center_y) * depth * constant_y;
-      *iter_z = DepthTraits<T>::toMeters(depth);
+      if (DepthTraits<T>::toMeters(depth) > range_min)
+      {
+        // Fill in XYZ
+        *iter_x = (u - center_x) * depth * constant_x;
+        *iter_y = (v - center_y) * depth * constant_y;
+        *iter_z = DepthTraits<T>::toMeters(depth);
+      }
+      else
+      {
+        *iter_x = *iter_y = *iter_z = bad_point;
+      }
     }
   }
 }

--- a/depth_image_proc/src/nodelets/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyz.cpp
@@ -58,6 +58,7 @@ class PointCloudXyzNodelet : public nodelet::Nodelet
   ros::Publisher pub_point_cloud_;
 
   image_geometry::PinholeCameraModel model_;
+  double range_min_;
 
   virtual void onInit();
 
@@ -75,6 +76,7 @@ void PointCloudXyzNodelet::onInit()
 
   // Read parameters
   private_nh.param("queue_size", queue_size_, 5);
+  private_nh.param("range_min", range_min_, 0.0);
 
   // Monitor whether anyone is subscribed to the output
   ros::SubscriberStatusCallback connect_cb = boost::bind(&PointCloudXyzNodelet::connectCb, this);
@@ -116,11 +118,11 @@ void PointCloudXyzNodelet::depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
 
   if (depth_msg->encoding == enc::TYPE_16UC1)
   {
-    convert<uint16_t>(depth_msg, cloud_msg, model_);
+    convert<uint16_t>(depth_msg, cloud_msg, model_, 0.0, range_min_);
   }
   else if (depth_msg->encoding == enc::TYPE_32FC1)
   {
-    convert<float>(depth_msg, cloud_msg, model_);
+    convert<float>(depth_msg, cloud_msg, model_, 0.0, range_min_);
   }
   else
   {


### PR DESCRIPTION
Sometimes, the created point cloud has points too close to the camera that we do not want. This will allow the user to remove all data points too close to the camera. 

Use on command-line: `rosrun nodelet nodelet load depth_image_proc/point_cloud_xyz nodelet_manager _range_min:=1.4`
