### PR TITLE
Scale pixels down from 16 to 8 bits instead of just clipping

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -256,7 +256,7 @@ class Calibrator(object):
         # TODO: get a Python API in cv_bridge to check for the image depth.
         if self.br.encoding_to_dtype_with_channels(msg.encoding)[0] in ['uint16', 'int16']:
             mono16 = self.br.imgmsg_to_cv2(msg, '16UC1')
-            mono8 = numpy.array(numpy.clip(mono16, 0, 255), dtype=numpy.uint8)
+            mono8 = numpy.array(mono16 / 256, dtype=numpy.uint8)
             return mono8
         elif 'FC1' in msg.encoding:
             # floating point image handling


### PR DESCRIPTION
Clipping 16 bit pixels just to 8 bit pixels leads to white images if the original image uses the full range of the 16 bits. Instead the pixel should be scaled down to 8 bits.