### PR TITLE
depth_image_proc/point_cloud_xyzi_radial Add intensity conversion (copy) for float

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzi.cpp
@@ -239,6 +239,11 @@ void PointCloudXyziNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_msg,
   {
     convert<uint16_t, uint16_t>(depth_msg, intensity_msg, cloud_msg);
   }
+  else if (depth_msg->encoding == enc::TYPE_16UC1 &&
+      intensity_msg->encoding == enc::TYPE_32FC1)
+  {
+    convert<uint16_t,float>(depth_msg, intensity_msg, cloud_msg);
+  }
   else if (depth_msg->encoding == enc::TYPE_32FC1 &&
       intensity_msg->encoding == enc::MONO8)
   {
@@ -248,6 +253,11 @@ void PointCloudXyziNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_msg,
       intensity_msg->encoding == enc::MONO16)
   {
     convert<float, uint16_t>(depth_msg, intensity_msg, cloud_msg);
+  }
+  else if (depth_msg->encoding == enc::TYPE_32FC1 &&
+      intensity_msg->encoding == enc::TYPE_32FC1)
+  {
+    convert<float,float>(depth_msg, intensity_msg, cloud_msg);
   }
   else
   {

--- a/depth_image_proc/src/nodelets/point_cloud_xyzi_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzi_radial.cpp
@@ -245,6 +245,10 @@ namespace depth_image_proc {
 	{
 	    convert_intensity<uint8_t>(intensity_msg, cloud_msg);
 	}
+	else if(intensity_msg->encoding == enc::TYPE_32FC1)
+	{
+	    convert_intensity<float>(intensity_msg, cloud_msg);
+	}
 	else
 	{
 	    NODELET_ERROR_THROTTLE(5, "Intensity image has unsupported encoding [%s]", intensity_msg->encoding.c_str());


### PR DESCRIPTION
This commit enables the generation of xyzi point clouds from 32-bit floating point intensity images.
The destination data type for intensity storage is 32-bit float, so all that is required is a data copy.
The change in this commit is simply an extension of the if-else statement to include the TYPE_32FC1 type and apply the usual convert_intensity() method.

This applies to the depth_image_proc/point_cloud_xyzi_radial and depth_image_proc/point_cloud_xyzi nodelets.

PS: I do have a 3D camera with a manufacturer-supported ROS driver providing me with 32-bit float intensity images.