### PR TITLE
distortion_coefficients size (cols) is not fixed, it depends on distortion mododel

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -495,7 +495,7 @@ class Calibrator(object):
         + "distortion_model: " + ("rational_polynomial" if d.size > 5 else "plumb_bob") + "\n"
         + "distortion_coefficients:\n"
         + "  rows: 1\n"
-        + "  cols: 5\n"
+        + "  cols: " + d.shape[0] + "\n"
         + "  data: [" + ", ".join(["%8f" % d[i,0] for i in range(d.shape[0])]) + "]\n"
         + "rectification_matrix:\n"
         + "  rows: 3\n"


### PR DESCRIPTION
discussed in #278, as discussed CameraInfo.msg, 
```
float64[] D
```
the size of D should not be fixed number (5)

c.f. http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html


NOTE : I haven't tested this code yet, someone?