### PR TITLE
Work around OpenCV highgui bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   # Install ROS
-  - sudo apt-get install -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - sudo apt-get install -y dpkg python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Setup for rosdep
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Setup for rosdep
   - sudo rosdep init
-  - rosdep update
+  - rosdep update --include-eol-distros
 
 # Create a catkin workspace with the package under test.
 install:

--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -42,27 +42,6 @@
 #include <boost/thread.hpp>
 #include <boost/format.hpp>
 
-#ifdef HAVE_GTK
-#include <gtk/gtk.h>
-
-// Platform-specific workaround for #3026: image_view doesn't close when
-// closing image window. On platforms using GTK+ we connect this to the
-// window's "destroy" event so that image_view exits.
-static void destroyNode(GtkWidget *widget, gpointer data)
-{
-  /// @todo On ros::shutdown(), the node hangs. Why?
-  //ros::shutdown();
-  exit(0); // brute force solution
-}
-
-static void destroyNodelet(GtkWidget *widget, gpointer data)
-{
-  // We can't actually unload the nodelet from here, but we can at least
-  // unsubscribe from the image topic.
-  reinterpret_cast<image_transport::Subscriber*>(data)->shutdown();
-}
-#endif
-
 
 namespace image_view {
 
@@ -78,12 +57,14 @@ class ImageNodelet : public nodelet::Nodelet
   boost::format filename_format_;
   int count_;
   bool initialized_;
+  ros::WallTimer gui_timer_;
 
   virtual void onInit();
   
   void imageCb(const sensor_msgs::ImageConstPtr& msg);
 
   static void mouseCb(int event, int x, int y, int flags, void* param);
+  static void guiCb(const ros::WallTimerEvent&);
 
 public:
   ImageNodelet();
@@ -134,17 +115,11 @@ void ImageNodelet::onInit()
   local_nh.param("filename_format", format_string, std::string("frame%04i.jpg"));
   filename_format_.parse(format_string);
 
-#ifdef HAVE_GTK
-  // Register appropriate handler for when user closes the display window
-  GtkWidget *widget = GTK_WIDGET( cvGetWindowHandle(window_name_.c_str()) );
-  if (shutdown_on_close)
-    g_signal_connect(widget, "destroy", G_CALLBACK(destroyNode), NULL);
-  else
-    g_signal_connect(widget, "destroy", G_CALLBACK(destroyNodelet), &sub_);
-#endif
-
-  // Start the OpenCV window thread so we don't have to waitKey() somewhere
-  startWindowThread();
+  // Since cv::startWindowThread() triggers a crash in cv::waitKey()
+  // if OpenCV is compiled against GTK, we call cv::waitKey() from
+  // the ROS event loop periodically, instead.
+  /*cv::startWindowThread();*/
+  gui_timer_ = local_nh.createWallTimer(ros::WallDuration(0.1), ImageNodelet::guiCb);
 
   image_transport::ImageTransport it(nh);
   image_transport::TransportHints hints(transport, ros::TransportHints(), getPrivateNodeHandle());
@@ -182,6 +157,12 @@ void ImageNodelet::imageCb(const sensor_msgs::ImageConstPtr& msg)
     cv::imshow(window_name_, last_image_);
     cv::waitKey(1);
   }
+}
+
+void ImageNodelet::guiCb(const ros::WallTimerEvent&)
+{
+  // Process pending GUI events and return immediately
+  cv::waitKey(1);
 }
 
 void ImageNodelet::mouseCb(int event, int x, int y, int flags, void* param)

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
   ros::NodeHandle nh;
   ros::NodeHandle local_nh("~");
-  ros::Timer gui_timer;
+  ros::WallTimer gui_timer;
 
   // Default window name is the resolved topic name
   std::string topic = nh.resolveName("image");

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -99,6 +99,7 @@ void imageCb(const sensor_msgs::ImageConstPtr& msg)
   if (g_gui && !g_last_image.empty()) {
     const cv::Mat &image = g_last_image;
     cv::imshow(g_window_name, image);
+    cv::waitKey(1);
   }
   if (g_pub.getNumSubscribers() > 0) {
     g_pub.publish(cv_ptr);

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -133,7 +133,7 @@ static void mouseCb(int event, int x, int y, int flags, void* param)
   }
 }
 
-static void guiCb(const ros::SteadyTimerEvent&)
+static void guiCb(const ros::WallTimerEvent&)
 {
     // Process pending GUI events and return immediately
     cv::waitKey(1);
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
     // if OpenCV is compiled against GTK, we call cv::waitKey() from
     // the ROS event loop periodically, instead.
     /*cv::startWindowThread();*/
-    gui_timer = local_nh.createSteadyTimer(ros::WallDuration(0.1), guiCb);
+    gui_timer = local_nh.createWallTimer(ros::WallDuration(0.1), guiCb);
   }
 
   // Handle transport

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -216,5 +216,11 @@ int main(int argc, char **argv)
   if (g_gui) {
     cv::destroyWindow(g_window_name);
   }
+  // The publisher is a global variable, and therefore its scope exceeds those
+  // of the node handles in main(). Unfortunately, this will cause a crash
+  // when the publisher tries to shut down and all node handles are gone
+  // already. Therefore, we shut down the publisher now and avoid the annoying
+  // mutex assertion.
+  g_pub.shutdown();
   return 0;
 }

--- a/image_view/src/nodes/image_view.cpp
+++ b/image_view/src/nodes/image_view.cpp
@@ -133,7 +133,7 @@ static void mouseCb(int event, int x, int y, int flags, void* param)
   }
 }
 
-static void guiCb(const ros::TimerEvent&)
+static void guiCb(const ros::SteadyTimerEvent&)
 {
     // Process pending GUI events and return immediately
     cv::waitKey(1);
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
     // if OpenCV is compiled against GTK, we call cv::waitKey() from
     // the ROS event loop periodically, instead.
     /*cv::startWindowThread();*/
-    gui_timer = local_nh.createTimer(ros::Duration(0.1), guiCb);
+    gui_timer = local_nh.createSteadyTimer(ros::WallDuration(0.1), guiCb);
   }
 
   // Handle transport


### PR DESCRIPTION
If OpenCV is compiled against GTK, running the GUI code in a dedicated thread will trigger a crash. While this is ultimately something for the OpenCV people to fix, we can work around the problem in the `image_view` node and fake a GUI thread with the help of  `ros::Timer`.

As a bonus, this PR also fixes the mutex assertion that occurs when the `image_view` program tries to shut down.

Fixes #201 
