### PR TITLE
implement registration: rgb to depth

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${PROJECT_NAME} src/nodelets/convert_metric.cpp
                              src/nodelets/point_cloud_xyz_radial.cpp
                              src/nodelets/point_cloud_xyzi_radial.cpp
                              src/nodelets/register.cpp
+                             src/nodelets/register_to_depth.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 

--- a/depth_image_proc/nodelet_plugins.xml
+++ b/depth_image_proc/nodelet_plugins.xml
@@ -61,6 +61,13 @@
       Nodelet to create a depth image registered to another camera frame.
     </description>
   </class>
+  <class name="depth_image_proc/register_to_depth"
+	 type="depth_image_proc::RegisterToDepthNodelet"
+	 base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to create a rgb image registered to another depth camera frame.
+    </description>
+  </class>
 
   <class name="depth_image_proc/crop_foremost"
 	 type="depth_image_proc::CropForemostNodelet"

--- a/depth_image_proc/src/nodelets/register_to_depth.cpp
+++ b/depth_image_proc/src/nodelets/register_to_depth.cpp
@@ -1,0 +1,384 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <image_transport/image_transport.h>
+#include <image_transport/subscriber_filter.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <sensor_msgs/image_encodings.h>
+#include <image_geometry/pinhole_camera_model.h>
+#include <Eigen/Geometry>
+#include <eigen_conversions/eigen_msg.h>
+#include <depth_image_proc/depth_traits.h>
+#include <cv_bridge/cv_bridge.h>
+
+namespace depth_image_proc {
+
+using namespace message_filters::sync_policies;
+namespace enc = sensor_msgs::image_encodings;
+
+class RegisterToDepthNodelet : public nodelet::Nodelet
+{
+  ros::NodeHandlePtr nh_depth_, nh_rgb_;
+  boost::shared_ptr<image_transport::ImageTransport> it_depth_, it_rgb_;
+
+  // Subscriptions
+  image_transport::SubscriberFilter sub_depth_image_, sub_rgb_image_;
+  message_filters::Subscriber<sensor_msgs::CameraInfo> sub_depth_info_, sub_rgb_info_;
+  boost::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  boost::shared_ptr<tf2_ros::TransformListener> tf_;
+  typedef ApproximateTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo> SyncPolicy;
+  typedef message_filters::Synchronizer<SyncPolicy> Synchronizer;
+  boost::shared_ptr<Synchronizer> sync_;
+
+  // Publications
+  boost::mutex connect_mutex_;
+  image_transport::CameraPublisher pub_registered_;
+
+  image_geometry::PinholeCameraModel depth_model_, rgb_model_;
+
+  virtual void onInit();
+
+  void connectCb();
+
+  void imageCb(const sensor_msgs::ImageConstPtr& depth_image_msg,
+               const sensor_msgs::ImageConstPtr& rgb_image_msg_in,
+               const sensor_msgs::CameraInfoConstPtr& depth_info_msg,
+               const sensor_msgs::CameraInfoConstPtr& rgb_info_msg);
+
+  template<typename T>
+  void convert(const sensor_msgs::ImageConstPtr& depth_msg,
+               const sensor_msgs::ImageConstPtr& rgb_msg,
+               const sensor_msgs::ImagePtr& registered_msg,
+               const Eigen::Affine3d& depth_to_rgb,
+               const Eigen::Affine3d& rgb_to_depth,
+               const int color_step);
+};
+
+void RegisterToDepthNodelet::onInit()
+{
+  ros::NodeHandle& nh         = getNodeHandle();
+  ros::NodeHandle& private_nh = getPrivateNodeHandle();
+  nh_depth_.reset( new ros::NodeHandle(nh, "depth") );
+  nh_rgb_.reset( new ros::NodeHandle(nh, "rgb") );
+  it_depth_.reset( new image_transport::ImageTransport(*nh_depth_) );
+  it_rgb_.reset( new image_transport::ImageTransport(*nh_rgb_) );
+  tf_buffer_.reset( new tf2_ros::Buffer );
+  tf_.reset( new tf2_ros::TransformListener(*tf_buffer_) );
+
+  // Read parameters
+  int queue_size;
+  private_nh.param("queue_size", queue_size, 5);
+
+  // Synchronize inputs. Topic subscriptions happen on demand in the connection callback.
+  sync_.reset( new Synchronizer(SyncPolicy(queue_size), sub_depth_image_, sub_rgb_image_, sub_depth_info_, sub_rgb_info_) );
+  sync_->registerCallback(boost::bind(&RegisterToDepthNodelet::imageCb, this, _1, _2, _3, _4));
+
+  // Monitor whether anyone is subscribed to the output
+  image_transport::ImageTransport it_rgb_reg(ros::NodeHandle(nh, "rgb_registered"));
+  image_transport::SubscriberStatusCallback image_connect_cb = boost::bind(&RegisterToDepthNodelet::connectCb, this);
+  ros::SubscriberStatusCallback info_connect_cb = boost::bind(&RegisterToDepthNodelet::connectCb, this);
+  // Make sure we don't enter connectCb() between advertising and assigning to pub_registered_
+  boost::lock_guard<boost::mutex> lock(connect_mutex_);
+  pub_registered_ = it_rgb_reg.advertiseCamera("image_rect", 1,
+                                                 image_connect_cb, image_connect_cb,
+                                                 info_connect_cb, info_connect_cb);
+}
+
+// Handles (un)subscribing when clients (un)subscribe
+void RegisterToDepthNodelet::connectCb()
+{
+  boost::lock_guard<boost::mutex> lock(connect_mutex_);
+  if (pub_registered_.getNumSubscribers() == 0)
+  {
+    sub_depth_image_.unsubscribe();
+    sub_rgb_image_  .unsubscribe();
+    sub_depth_info_ .unsubscribe();
+    sub_rgb_info_   .unsubscribe();
+  }
+  else if (!sub_depth_image_.getSubscriber())
+  {
+    image_transport::TransportHints hints("raw", ros::TransportHints(), getPrivateNodeHandle());
+    sub_depth_image_.subscribe(*it_depth_, "image_rect",  1, hints);
+    sub_rgb_image_  .subscribe(*it_rgb_,   "image_rect",  1, hints);
+    sub_depth_info_ .subscribe(*nh_depth_, "camera_info", 1);
+    sub_rgb_info_   .subscribe(*nh_rgb_,   "camera_info", 1);
+  }
+}
+
+void RegisterToDepthNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_image_msg,
+                                     const sensor_msgs::ImageConstPtr& rgb_image_msg_in,
+                                     const sensor_msgs::CameraInfoConstPtr& depth_info_msg,
+                                     const sensor_msgs::CameraInfoConstPtr& rgb_info_msg)
+{
+  // Update camera models - these take binning & ROI into account
+  depth_model_.fromCameraInfo(depth_info_msg);
+  rgb_model_  .fromCameraInfo(rgb_info_msg);
+
+  // Check if the input image has to be resized
+  sensor_msgs::ImageConstPtr rgb_image_msg = rgb_image_msg_in;
+  if (depth_image_msg->width != rgb_image_msg->width || depth_image_msg->height != rgb_image_msg->height)
+  {
+    sensor_msgs::CameraInfo info_msg_tmp = *rgb_info_msg;
+    info_msg_tmp.width = depth_image_msg->width;
+    info_msg_tmp.height = depth_image_msg->height;
+    float ratio = float(depth_image_msg->width)/float(rgb_image_msg->width);
+    info_msg_tmp.K[0] *= ratio;
+    info_msg_tmp.K[2] *= ratio;
+    info_msg_tmp.K[4] *= ratio;
+    info_msg_tmp.K[5] *= ratio;
+    info_msg_tmp.P[0] *= ratio;
+    info_msg_tmp.P[2] *= ratio;
+    info_msg_tmp.P[5] *= ratio;
+    info_msg_tmp.P[6] *= ratio;
+    rgb_model_.fromCameraInfo(info_msg_tmp);
+
+    cv_bridge::CvImageConstPtr cv_ptr;
+    try
+    {
+      cv_ptr = cv_bridge::toCvShare(rgb_image_msg, rgb_image_msg->encoding);
+    }
+    catch (cv_bridge::Exception& e)
+    {
+      ROS_ERROR("cv_bridge exception: %s", e.what());
+      return;
+    }
+    cv_bridge::CvImage cv_rsz;
+    cv_rsz.header = cv_ptr->header;
+    cv_rsz.encoding = cv_ptr->encoding;
+    cv::resize(cv_ptr->image.rowRange(0,depth_image_msg->height/ratio), cv_rsz.image, cv::Size(depth_image_msg->width, depth_image_msg->height));
+    if ((rgb_image_msg->encoding == enc::RGB8) || (rgb_image_msg->encoding == enc::BGR8) || (rgb_image_msg->encoding == enc::MONO8))
+      rgb_image_msg = cv_rsz.toImageMsg();
+    else
+      rgb_image_msg = cv_bridge::toCvCopy(cv_rsz.toImageMsg(), enc::RGB8)->toImageMsg();
+
+    //NODELET_ERROR_THROTTLE(5, "Depth resolution (%ux%u) does not match RGB resolution (%ux%u)",
+    //                       depth_image_msg->width, depth_image_msg->height, rgb_image_msg->width, rgb_image_msg->height);
+    //return;
+  } else
+    rgb_image_msg = rgb_image_msg_in;
+
+  // Supported color encodings: RGB8, BGR8, MONO8
+  int color_step;
+  if (rgb_image_msg->encoding == enc::RGB8)
+  {
+    color_step   = 3;
+  }
+  else if (rgb_image_msg->encoding == enc::BGR8)
+  {
+    color_step   = 3;
+  }
+  else if (rgb_image_msg->encoding == enc::MONO8)
+  {
+    color_step   = 1;
+  }
+  else
+  {
+    try
+    {
+      rgb_image_msg = cv_bridge::toCvCopy(rgb_image_msg, enc::RGB8)->toImageMsg();
+    }
+    catch (cv_bridge::Exception& e)
+    {
+      NODELET_ERROR_THROTTLE(5, "Unsupported encoding [%s]: %s", rgb_image_msg->encoding.c_str(), e.what());
+      return;
+    }
+    color_step   = 3;
+  }
+  // Query tf2 for transform from (X,Y,Z) in RGB camera frame to depth camera frame
+  Eigen::Affine3d rgb_to_depth;
+  try
+  {
+    geometry_msgs::TransformStamped transform = tf_buffer_->lookupTransform (
+                          depth_info_msg->header.frame_id, rgb_info_msg->header.frame_id,
+                          depth_info_msg->header.stamp);
+
+    tf::transformMsgToEigen(transform.transform, rgb_to_depth);
+  }
+  catch (tf2::TransformException& ex)
+  {
+    NODELET_WARN_THROTTLE(2, "TF2 exception:\n%s", ex.what());
+    return;
+    /// @todo Can take on order of a minute to register a disconnect callback when we
+    /// don't call publish() in this cb. What's going on roscpp?
+  }
+
+  // Query tf2 for transform from (X,Y,Z) in depth camera frame to RGB camera frame
+  Eigen::Affine3d depth_to_rgb;
+  try
+  {
+    geometry_msgs::TransformStamped transform = tf_buffer_->lookupTransform (
+                          rgb_info_msg->header.frame_id, depth_info_msg->header.frame_id,
+                          depth_info_msg->header.stamp);
+
+    tf::transformMsgToEigen(transform.transform, depth_to_rgb);
+  }
+  catch (tf2::TransformException& ex)
+  {
+    NODELET_WARN_THROTTLE(2, "TF2 exception:\n%s", ex.what());
+    return;
+    /// @todo Can take on order of a minute to register a disconnect callback when we
+    /// don't call publish() in this cb. What's going on roscpp?
+  }
+
+  // Allocate registered depth image
+  sensor_msgs::ImagePtr registered_msg( new sensor_msgs::Image );
+  registered_msg->header.stamp    = rgb_image_msg->header.stamp;
+  registered_msg->header.frame_id = depth_info_msg->header.frame_id;
+  registered_msg->encoding        = rgb_image_msg->encoding;
+
+  cv::Size resolution = depth_model_.reducedResolution();
+  registered_msg->height = resolution.height;
+  registered_msg->width  = resolution.width;
+  // step and data set in convert(), depend on depth data type
+
+  if (depth_image_msg->encoding == enc::TYPE_16UC1)
+  {
+    convert<uint16_t>(depth_image_msg, rgb_image_msg, registered_msg, depth_to_rgb, rgb_to_depth, color_step);
+  }
+  else if (depth_image_msg->encoding == enc::TYPE_32FC1)
+  {
+    convert<float>(depth_image_msg, rgb_image_msg, registered_msg, depth_to_rgb, rgb_to_depth, color_step);
+  }
+  else
+  {
+    NODELET_ERROR_THROTTLE(5, "Depth image has unsupported encoding [%s]", depth_image_msg->encoding.c_str());
+    return;
+  }
+
+  // Registered camera info is the same as the RGB info, but uses the depth timestamp
+  sensor_msgs::CameraInfoPtr registered_info_msg( new sensor_msgs::CameraInfo(*depth_info_msg) );
+  registered_info_msg->header.stamp = registered_msg->header.stamp;
+
+  pub_registered_.publish(registered_msg, registered_info_msg);
+}
+
+template<typename T>
+void RegisterToDepthNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
+                                     const sensor_msgs::ImageConstPtr& rgb_msg,
+                                     const sensor_msgs::ImagePtr& registered_msg,
+                                     const Eigen::Affine3d& depth_to_rgb,
+                                     const Eigen::Affine3d& rgb_to_depth,
+                                     const int color_step)
+{
+  // Allocate memory for depth values in RGB camera frame
+  std::vector<T> temp_depth_data;
+  temp_depth_data.resize( rgb_msg->height * rgb_msg->width, std::numeric_limits<T>::quiet_NaN());
+
+  // Allocate memory for uv coordinates in depth camera frame
+  std::vector<cv::Point> uv_depth;
+  uv_depth.resize(rgb_msg->width*rgb_msg->height);
+
+  // Allocate memory for registered depth image
+  registered_msg->step = registered_msg->width * color_step;
+  registered_msg->data.resize( registered_msg->height * registered_msg->step );
+
+  // Extract all the parameters we need
+  double inv_depth_fx = 1.0 / depth_model_.fx();
+  double inv_depth_fy = 1.0 / depth_model_.fy();
+  double depth_cx = depth_model_.cx(), depth_cy = depth_model_.cy();
+  double depth_Tx = depth_model_.Tx(), depth_Ty = depth_model_.Ty();
+  double rgb_fx = rgb_model_.fx(), rgb_fy = rgb_model_.fy();
+  double rgb_cx = rgb_model_.cx(), rgb_cy = rgb_model_.cy();
+  double rgb_Tx = rgb_model_.Tx(), rgb_Ty = rgb_model_.Ty();
+
+  // Transform the depth values into the RGB frame
+  /// @todo When RGB is higher res, interpolate by rasterizing depth triangles onto the registered image
+  const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
+  int row_step = depth_msg->step / sizeof(T);
+  int raw_index = 0;
+  for (unsigned v = 0; v < depth_msg->height; ++v, depth_row += row_step)
+  {
+    for (unsigned u = 0; u < depth_msg->width; ++u, ++raw_index)
+    {
+      T raw_depth = depth_row[u];
+      if (!DepthTraits<T>::valid(raw_depth))
+        continue;
+
+      double depth = DepthTraits<T>::toMeters(raw_depth);
+
+      /// @todo Combine all operations into one matrix multiply on (u,v,d)
+      // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
+      Eigen::Vector4d xyz_depth;
+      xyz_depth << ((u - depth_cx)*depth - depth_Tx) * inv_depth_fx,
+                   ((v - depth_cy)*depth - depth_Ty) * inv_depth_fy,
+                   depth,
+                   1;
+
+      // Transform to RGB camera frame
+      Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
+
+      // Project to (u,v) in RGB image
+      double inv_Z = 1.0 / xyz_rgb.z();
+      int u_rgb = (rgb_fx*xyz_rgb.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
+      int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+
+      if (u_rgb < 0 || u_rgb >= (int)rgb_msg->width ||
+          v_rgb < 0 || v_rgb >= (int)rgb_msg->height)
+        continue;
+
+      T& temp_depth = temp_depth_data[v_rgb*rgb_msg->width + u_rgb];
+      T  new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
+      // Validity and Z-buffer checks
+      if (!DepthTraits<T>::valid(temp_depth) || temp_depth > new_depth)
+      {
+        temp_depth = new_depth;
+        uv_depth[v_rgb*rgb_msg->width + u_rgb] = cv::Point(u, v);
+      }
+    }
+  }
+
+  // Construct RGB image
+  for (unsigned v = 0; v < rgb_msg->height; ++v)
+  {
+    for (unsigned u = 0; u < rgb_msg->width; ++u)
+    {
+      cv::Point pt = uv_depth[v*rgb_msg->width + u];
+      const unsigned u_depth = pt.x, v_depth = pt.y;
+
+      std::memcpy(&registered_msg->data[v_depth*registered_msg->step + u_depth*color_step],
+                  &rgb_msg->data[v*rgb_msg->step + u*color_step], color_step);
+    }
+  }
+}
+
+} // namespace depth_image_proc
+
+// Register as nodelet
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(depth_image_proc::RegisterToDepthNodelet,nodelet::Nodelet);


### PR DESCRIPTION
I wrote additional nodelet for registration from rgb frame to depth frame. I am using Intel Realsense d435. RGB camara's fov is just 70 degree, even though depth camera's fov about 90 degree. I want to use a wider fov frame.