### PR TITLE
[stereo_image_proc] Removed disparity pre-adjustment (cx_l - cx_r subtraction).

### DIFF
--- a/stereo_image_proc/src/libstereo_image_proc/processor.cpp
+++ b/stereo_image_proc/src/libstereo_image_proc/processor.cpp
@@ -108,9 +108,8 @@ void StereoProcessor::processDisparity(const cv::Mat& left_rect, const cv::Mat& 
   dimage.step = dimage.width * sizeof(float);
   dimage.data.resize(dimage.step * dimage.height);
   cv::Mat_<float> dmat(dimage.height, dimage.width, (float*)&dimage.data[0], dimage.step);
-  // We convert from fixed-point to float disparity and also adjust for any x-offset between
-  // the principal points: d = d_fp*inv_dpp - (cx_l - cx_r)
-  disparity16_.convertTo(dmat, dmat.type(), inv_dpp, -(model.left().cx() - model.right().cx()));
+  // We convert from fixed-point to float disparity: d = d_fp*inv_dpp
+  disparity16_.convertTo(dmat, dmat.type(), inv_dpp);
   ROS_ASSERT(dmat.data == &dimage.data[0]);
   /// @todo is_bigendian? :)
 

--- a/stereo_image_proc/src/nodelets/disparity.cpp
+++ b/stereo_image_proc/src/nodelets/disparity.cpp
@@ -199,16 +199,6 @@ void DisparityNodelet::imageCb(const ImageConstPtr& l_image_msg,
   // Perform block matching to find the disparities
   block_matcher_.processDisparity(l_image, r_image, model_, *disp_msg);
 
-  // Adjust for any x-offset between the principal points: d' = d - (cx_l - cx_r)
-  double cx_l = model_.left().cx();
-  double cx_r = model_.right().cx();
-  if (cx_l != cx_r) {
-    cv::Mat_<float> disp_image(disp_msg->image.height, disp_msg->image.width,
-                              reinterpret_cast<float*>(&disp_msg->image.data[0]),
-                              disp_msg->image.step);
-    cv::subtract(disp_image, cv::Scalar(cx_l - cx_r), disp_image);
-  }
-
   pub_disparity_.publish(disp_msg);
 }
 


### PR DESCRIPTION
First of all, this change has no effect if the two cameras are parallel (cx_l == cx_r).
**The following description is for the case that they are verged (cx_l != cx_r).**

https://github.com/ros/common_msgs/blob/42e6a7d87f6bdf17c6dce5f7fe9456ceedc014b8/stereo_msgs/msg/DisparityImage.msg#L5-L8
says that
  \# Floating point disparity image. The disparities are pre-adjusted for any
  \# x-offset between the principal points of the two cameras (in the case
  \# that they are verged). That is: d = x_l - x_r - (cx_l - cx_r)
, but with this pre-adjustment we get incorrect depth (Z) values.

It should be not '_d = x_l - x_r - (cx_l - cx_r)_' but '**d = x_l - x_r**'.

For example, PointCloud2Nodelet calculates point cloud using these pre-adjusted disparities
(
https://github.com/ros-perception/image_pipeline/blob/8d01c930e66bdeb58c4b138539a64ddea0b17e10/stereo_image_proc/src/nodelets/point_cloud2.cpp#L170
https://github.com/ros-perception/vision_opencv/blob/a3736d24554166142981fa2bcf3d7d3c6e3ce366/image_geometry/src/stereo_camera_model.cpp#L132-L138
),
but `cv::reprojectImageTo3D()` uses Q_ matrix and Q_ includes cx_l and cx_r information!
So if we pre-adjust disparities, we get incorrect depth values.

Simpler exaple:
https://github.com/ros-perception/vision_opencv/blob/a3736d24554166142981fa2bcf3d7d3c6e3ce366/image_geometry/include/image_geometry/stereo_camera_model.h#L116-L120
is correct if the disparity is NOT pre-adjusted.

(And I found an implementation bug...
Both
https://github.com/ros-perception/image_pipeline/blob/8d01c930e66bdeb58c4b138539a64ddea0b17e10/stereo_image_proc/src/libstereo_image_proc/processor.cpp#L113
and
https://github.com/ros-perception/image_pipeline/blob/8d01c930e66bdeb58c4b138539a64ddea0b17e10/stereo_image_proc/src/nodelets/disparity.cpp#L209
subtract cx_l - cx_r, so
d = x_l - x_r - 2 * (cx_l - cx_r).
But by this commit, these subtraction codes are removed, so we don't care about it.
(Now d = cx_l - cx_r.))

After this pull request is merged, I'll create two pull requests.
1. remove comment of
https://github.com/ros-perception/vision_opencv/blob/a3736d24554166142981fa2bcf3d7d3c6e3ce366/image_geometry/src/stereo_camera_model.cpp#L112
2. change comments of
https://github.com/ros/common_msgs/blob/jade-devel/stereo_msgs/msg/DisparityImage.msg

**And I have one concern...**
https://github.com/ros-perception/vision_opencv/blob/kinetic/image_geometry/src/image_geometry/cameramodels.py
seems to depend on this pre-adjustment, so **if we remove disparity pre-adjustment, we need to change cameramodels.py also?**
(I don't use python, so I can't test it.)