### PR TITLE
depth_image_proc: fix support for mono16 intensity encoding in point_cloud_xyzi node

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzi.cpp
@@ -199,7 +199,7 @@ void PointCloudXyziNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_msg,
     intensity_msg = intensity_msg_in;
 
   // Supported color encodings: MONO8, MONO16
-  if (intensity_msg->encoding != enc::MONO8 || intensity_msg->encoding != enc::MONO16)
+  if (intensity_msg->encoding != enc::MONO8 && intensity_msg->encoding != enc::MONO16)
   {
     try
     {


### PR DESCRIPTION
There is a conditional that previously would always evaluate to `true`, regardless of the inputs. Fixes #353 