### PR TITLE
Enhance calibration of rolling shutter cameras (fixes #325, possibly #281)

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -41,6 +41,7 @@ from camera_calibration.camera_calibrator import OpenCVCalibrationNode
 from camera_calibration.calibrator import ChessboardInfo, Patterns
 from message_filters import ApproximateTimeSynchronizer
 
+
 def main():
     from optparse import OptionParser, OptionGroup
     parser = OptionParser("%prog --size SIZE1 --square SQUARE1 [ --size SIZE2 --square SQUARE2 ]",
@@ -84,8 +85,8 @@ def main():
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     group.add_option("--max-chessboard-speed", type="float", default=-1.0,
-                     help="Do not use samples where the chessboard is moving faster than this speed in \
-                     px/frame. Set to eg. 0.5 for rolling shutter cameras.")
+                     help="Do not use samples where the calibration pattern is moving faster \
+                     than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
     parser.add_option_group(group)
     options, args = parser.parse_args()
 

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -41,7 +41,6 @@ from camera_calibration.camera_calibrator import OpenCVCalibrationNode
 from camera_calibration.calibrator import ChessboardInfo, Patterns
 from message_filters import ApproximateTimeSynchronizer
 
-
 def main():
     from optparse import OptionParser, OptionGroup
     parser = OptionParser("%prog --size SIZE1 --square SQUARE1 [ --size SIZE2 --square SQUARE2 ]",
@@ -84,6 +83,9 @@ def main():
                      help="number of radial distortion coefficients to use (up to 6, default %default)")
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
+    group.add_option("--max-chessboard-speed", type="float", default=-1.0,
+                     help="Do not use samples where the chessboard is moving faster than this speed in \
+                     px/frame. Set to eg. 0.5 for rolling shutter cameras.")
     parser.add_option_group(group)
     options, args = parser.parse_args()
 
@@ -143,7 +145,7 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
-                                 checkerboard_flags=checkerboard_flags)
+                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1114,11 +1114,12 @@ class StereoCalibrator(Calibrator):
             # Add sample to database only if it's sufficiently different from any previous sample
             if lcorners is not None and rcorners is not None and len(lcorners) == len(rcorners):
                 params = self.get_parameters(lcorners, lboard, (lgray.shape[1], lgray.shape[0]))
-                if self.is_good_sample(params):
+                if self.is_good_sample(params, lcorners, self.last_frame_corners):
                     self.db.append( (params, lgray, rgray) )
                     self.good_corners.append( (lcorners, rcorners, lboard) )
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
-
+        
+        self.last_frame_corners = lcorners
         rv = StereoDrawable()
         rv.lscrib = lscrib
         rv.rscrib = rscrib

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -218,7 +218,8 @@ class Calibrator(object):
     """
     Base class for calibration system
     """
-    def __init__(self, boards, flags=0, pattern=Patterns.Chessboard, name='', checkerboard_flags=cv2.CALIB_CB_FAST_CHECK):
+    def __init__(self, boards, flags=0, pattern=Patterns.Chessboard, name='', 
+    checkerboard_flags=cv2.CALIB_CB_FAST_CHECK, max_chessboard_speed = -1.0):
         # Ordering the dimensions for the different detectors is actually a minefield...
         if pattern == Patterns.Chessboard:
             # Make sure n_cols > n_rows to agree with OpenCV CB detector output
@@ -247,6 +248,8 @@ class Calibrator(object):
         self.goodenough = False
         self.param_ranges = [0.7, 0.7, 0.4, 0.5]
         self.name = name
+        self.last_frame_corners = None
+        self.max_chessboard_speed = max_chessboard_speed
 
     def mkgray(self, msg):
         """
@@ -289,7 +292,22 @@ class Calibrator(object):
         params = [p_x, p_y, p_size, skew]
         return params
 
-    def is_good_sample(self, params):
+    def is_slow_moving(self, corners, last_frame_corners):
+        """
+        Returns true if the motion of the checkerboard is sufficiently low between
+        this and the previous frame.
+        """
+        # If we don't have previous frame corners, we can't accept the sample
+        if last_frame_corners is None:
+            return False
+        num_corners = len(corners)
+        corner_deltas = (corners - last_frame_corners).reshape(num_corners, 2)
+        # Average distance travelled overall for all corners
+        average_motion = numpy.average(numpy.linalg.norm(corner_deltas, axis = 1))
+        print ("average motion: %g" % average_motion)
+        return average_motion <= self.max_chessboard_speed
+
+    def is_good_sample(self, params, corners, last_frame_corners):
         """
         Returns true if the checkerboard detection described by params should be added to the database.
         """
@@ -303,7 +321,15 @@ class Calibrator(object):
         d = min([param_distance(params, p) for p in db_params])
         #print "d = %.3f" % d #DEBUG
         # TODO What's a good threshold here? Should it be configurable?
-        return d > 0.2
+        if d <= 0.2:
+            return False
+
+        if self.max_chessboard_speed > 0:
+            if not self.is_slow_moving(corners, last_frame_corners):
+                return False
+
+        # All tests passed
+        return True
 
     _param_names = ["X", "Y", "Size", "Skew"]
 
@@ -767,11 +793,12 @@ class MonoCalibrator(Calibrator):
 
                 # Add sample to database only if it's sufficiently different from any previous sample.
                 params = self.get_parameters(corners, board, (gray.shape[1], gray.shape[0]))
-                if self.is_good_sample(params):
+                if self.is_good_sample(params, corners, self.last_frame_corners):
                     self.db.append((params, gray))
                     self.good_corners.append((corners, board))
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
-
+        
+        self.last_frame_corners = corners
         rv = MonoDrawable()
         rv.scrib = scrib
         rv.params = self.compute_goodenough()

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -327,7 +327,7 @@ class Calibrator(object):
             if not self.is_slow_moving(corners, last_frame_corners):
                 return False
 
-        # All tests passed
+        # All tests passed, image should be good for calibration
         return True
 
     _param_names = ["X", "Y", "Size", "Skew"]

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -304,7 +304,6 @@ class Calibrator(object):
         corner_deltas = (corners - last_frame_corners).reshape(num_corners, 2)
         # Average distance travelled overall for all corners
         average_motion = numpy.average(numpy.linalg.norm(corner_deltas, axis = 1))
-        print ("average motion: %g" % average_motion)
         return average_motion <= self.max_chessboard_speed
 
     def is_good_sample(self, params, corners, last_frame_corners):

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -92,7 +92,7 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0):
+                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, max_chessboard_speed = -1):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -112,6 +112,7 @@ class CalibrationNode:
         self._checkerboard_flags = checkerboard_flags
         self._pattern = pattern
         self._camera_name = camera_name
+        self._max_chessboard_speed = max_chessboard_speed
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)
@@ -155,10 +156,12 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                        checkerboard_flags=self._checkerboard_flags)
+                                        checkerboard_flags=self._checkerboard_flags,
+                                        max_chessboard_speed = self._max_chessboard_speed)
             else:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                        checkerboard_flags=self.checkerboard_flags)
+                                        checkerboard_flags=self.checkerboard_flags,
+                                        max_chessboard_speed = self._max_chessboard_speed)
 
         # This should just call the MonoCalibrator
         drawable = self.c.handle_msg(msg)
@@ -169,10 +172,12 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          checkerboard_flags=self._checkerboard_flags,
+                                          max_chessboard_speed = self._max_chessboard_speed)
             else:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          checkerboard_flags=self._checkerboard_flags,
+                                          max_chessboard_speed = self._max_chessboard_speed)
 
         drawable = self.c.handle_msg(msg)
         self.displaywidth = drawable.lscrib.shape[1] + drawable.rscrib.shape[1]


### PR DESCRIPTION
This pull request aims to improve the calibration accuracy of rolling shutter cameras by avoiding picking frames where the chessboard pattern is moving in the image frame. This should fix #325 .
This is controlled by the --max-chessboard-speed option that allows setting a maximum allowed speed in pixels/frame for the chessboard. If the chessboard is moving faster than the allowed speed, the frame is not picked to be used for calibration.

The chessboard speed is determined by measuring the average distance that each chessboard feature traveled between this and the previous frame.
