### PR TITLE
Use a shared_ptr for the dynamic reconfigure pointer, and create it w…

### DIFF
--- a/image_publisher/src/nodelet/image_publisher_nodelet.cpp
+++ b/image_publisher/src/nodelet/image_publisher_nodelet.cpp
@@ -48,7 +48,8 @@ using namespace boost::assign;
 namespace image_publisher {
 class ImagePublisherNodelet : public nodelet::Nodelet
 {
-  dynamic_reconfigure::Server<image_publisher::ImagePublisherConfig> srv;
+  typedef dynamic_reconfigure::Server<image_publisher::ImagePublisherConfig> ReconfigureServer;
+  boost::shared_ptr<ReconfigureServer> srv;
 
   image_transport::CameraPublisher pub_;
 
@@ -184,9 +185,10 @@ public:
 
     timer_ = nh_.createTimer(ros::Duration(1), &ImagePublisherNodelet::do_work, this);
 
-    dynamic_reconfigure::Server<image_publisher::ImagePublisherConfig>::CallbackType f =
+    srv.reset(new ReconfigureServer(getPrivateNodeHandle()));
+    ReconfigureServer::CallbackType f =
       boost::bind(&ImagePublisherNodelet::reconfigureCallback, this, _1, _2);
-    srv.setCallback(f);
+    srv->setCallback(f);
   }
 };
 }


### PR DESCRIPTION
…ith the private node handle so that the parameters for the dynamic reconfigure server are in the private namespace and two image publishers can coexist in the same manager #357 

This may break parameters that were set in the nodelet manager  namespace as a workaround in some launch files out there.