### PR TITLE
[Fix] RuntimeError: cv_bridge.cvtColorForDisplay() while trying to convert image from '8UC3' to 'bgr8' an exception was thrown ([8UC3] is not a color format. but [bgr8] is. #377

### DIFF
--- a/image_view/scripts/extract_images_sync
+++ b/image_view/scripts/extract_images_sync
@@ -81,12 +81,12 @@ _inputs:='[<image_topic>, <image_topic>]'""")
         bridge = cv_bridge.CvBridge()
         for i, imgmsg in enumerate(imgmsgs):
             img = bridge.imgmsg_to_cv2(imgmsg)
-            channels = img.shape[2] if img.ndim == 3 else 1
-            encoding_in = bridge.dtype_with_channels_to_cvtype2(
-                img.dtype, channels)
-            img = cv_bridge.cvtColorForDisplay(
-                img, encoding_in=encoding_in, encoding_out='',
-                do_dynamic_scaling=self.do_dynamic_scaling)
+            #channels = img.shape[2] if img.ndim == 3 else 1
+            #encoding_in = bridge.dtype_with_channels_to_cvtype2(
+            #    img.dtype, channels)
+            #img = cv_bridge.cvtColorForDisplay(
+            #    img, encoding_in=encoding_in, encoding_out='',
+            #    do_dynamic_scaling=self.do_dynamic_scaling)
             fname = self.fname_fmt % (seq, i)
             print('Save image as {0}'.format(fname))
             cv2.imwrite(fname, img)


### PR DESCRIPTION
```sh
ubuntu@ubuntu:~/catkin_csi_camera$ rosrun image_view extract_images_sync _inputs:='[/csi_cam/image_raw]'
[ERROR] [1547019957.683194]: bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7f54800390>>
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 75, in callback
    self.signalMessage(msg)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 57, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 224, in add
    self.signalMessage(*msgs)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 57, in signalMessage
    cb(*(msg + args))
  File "/home/ubuntu/catkin_csi_camera/src/image_view/scripts/extract_images_sync", line 89, in save
    do_dynamic_scaling=self.do_dynamic_scaling)
RuntimeError: cv_bridge.cvtColorForDisplay() while trying to convert image from '8UC3' to 'bgr8' an exception was thrown ([8UC3] is not a color format. but [bgr8] is. The conversion does not make sense)
```