### PR TITLE
Fix tf timeout of image_rotate 

### DIFF
--- a/image_rotate/src/nodelet/image_rotate_nodelet.cpp
+++ b/image_rotate/src/nodelet/image_rotate_nodelet.cpp
@@ -265,7 +265,7 @@ public:
     it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
     subscriber_count_ = 0;
     angle_ = 0;
-    prev_stamp_ = ros::Time(0, 0);
+    prev_stamp_ = ros::Time::now();
     tf_sub_.reset(new tf2_ros::TransformListener(tf_buffer_));
     image_transport::SubscriberStatusCallback connect_cb    = boost::bind(&ImageRotateNodelet::connectCb, this, _1);
     image_transport::SubscriberStatusCallback disconnect_cb = boost::bind(&ImageRotateNodelet::disconnectCb, this, _1);


### PR DESCRIPTION
* If prev_stamp_ is initialized as 0.0, tf may [wait for transformation for
  long duration](https://github.com/ros-perception/image_pipeline/blob/indigo/image_rotate/src/nodelet/image_rotate_nodelet.cpp#L127) for the first time. In order to give up the wait in
  reasonable duration, initialize prev_stamp_ as the current time.