### PR TITLE
image_view: video recorder fix for conversion of fps to ros::Duration

### DIFF
--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -70,7 +70,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg)
 
     }
 
-    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1 / fps))
+    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1.0 / fps))
     {
       // Skip to get video with correct fps
       return;


### PR DESCRIPTION
Fix for video recording at requested FPS.
1/fps will give 0 (integer) for fps>1
1.0/fps will give a float number that will corresponding to the requested time period of recording