### PR TITLE
Set the flip and filename through dynamic reconfigure

### DIFF
--- a/image_publisher/cfg/ImagePublisher.cfg
+++ b/image_publisher/cfg/ImagePublisher.cfg
@@ -40,5 +40,8 @@ gen = ParameterGenerator()
 gen.add("frame_id", str_t, 0, "Frame to use for camera image", "camera")
 gen.add("publish_rate", double_t, 0, "Rate to publish image", 10, 0.1, 30)
 gen.add("camera_info_url", str_t, 0, "Path to camera_info", "")
+gen.add("filename", str_t, 0, "Path to image", "")
+gen.add("flip_horizontal", bool_t, 0, "Flip image horizontally", False)
+gen.add("flip_vertical", bool_t, 0, "Flip image vertically", False)
 
 exit(gen.generate(PACKAGE, "image_publisher", "ImagePublisher"))

--- a/image_publisher/src/node/image_publisher.cpp
+++ b/image_publisher/src/node/image_publisher.cpp
@@ -38,13 +38,11 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "image_publisher", ros::init_options::AnonymousName);
 
-  if (argc <= 1) {
-    ROS_ERROR("image_publisher requires filename. Typical command-line usage:\n"
-              "\t$ rosrun image_publisher image_publisher <filename>");
-    return 1;
+  // filename supplied as parameter will be overridden by filename as arg
+  if (argc > 1) {
+    ros::param::set("~filename", argv[1]);
   }
 
-  ros::param::set("~filename", argv[1]);
   nodelet::Loader manager(false);
   nodelet::M_string remappings;
   nodelet::V_string my_argv(argv + 1, argv + argc);

--- a/image_publisher/src/nodelet/image_publisher_nodelet.cpp
+++ b/image_publisher/src/nodelet/image_publisher_nodelet.cpp
@@ -50,6 +50,7 @@ class ImagePublisherNodelet : public nodelet::Nodelet
 {
   typedef dynamic_reconfigure::Server<image_publisher::ImagePublisherConfig> ReconfigureServer;
   boost::shared_ptr<ReconfigureServer> srv;
+  image_publisher::ImagePublisherConfig config_;
 
   image_transport::CameraPublisher pub_;
 
@@ -57,35 +58,112 @@ class ImagePublisherNodelet : public nodelet::Nodelet
   ros::NodeHandle nh_;
 
   cv::VideoCapture cap_;
-  cv::Mat image_;
+  cv::Mat original_image_;
+  cv::Mat flipped_image_;
   int subscriber_count_;
   ros::Timer timer_;
 
-  std::string frame_id_;
-  std::string filename_;
   bool flip_image_;
   int flip_value_;
   sensor_msgs::CameraInfo camera_info_;
-  
+  bool initted_ = false;
+  bool image_dirty_ = false;
+
+  void flip_if_needed()
+  {
+    if (!image_dirty_) {
+      return;
+    }
+    if (original_image_.empty()) {
+      return;
+    }
+    if (flip_image_) {
+      // flipped_image_ = cv::Mat();
+      cv::flip(original_image_, flipped_image_, flip_value_);
+    } else {
+      flipped_image_ = original_image_.clone();
+    }
+    image_dirty_ = false;
+  }
 
   void reconfigureCallback(image_publisher::ImagePublisherConfig &new_config, uint32_t level)
   {
-    frame_id_ = new_config.frame_id;
+    // TODO(lucasw) could move this out of reconfigure callback,
+    if (!initted_ || (new_config.publish_rate != config_.publish_rate)) {
+      timer_ = nh_.createTimer(ros::Duration(1.0/new_config.publish_rate), &ImagePublisherNodelet::do_work, this);
+    }
 
-    timer_ = nh_.createTimer(ros::Duration(1.0/new_config.publish_rate), &ImagePublisherNodelet::do_work, this);
-
-    camera_info_manager::CameraInfoManager c(nh_);
-    if ( !new_config.camera_info_url.empty() ) {
-      try {
-        c.validateURL(new_config.camera_info_url);
-        c.loadCameraInfo(new_config.camera_info_url);
-        camera_info_ = c.getCameraInfo();
-      } catch(cv::Exception &e) {
-        NODELET_ERROR("camera calibration failed to load: %s %s %s %i", e.err.c_str(), e.func.c_str(), e.file.c_str(), e.line);
+    if (!initted_ || (new_config.camera_info_url != config_.camera_info_url)) {
+      camera_info_manager::CameraInfoManager c(nh_);
+      if ( !new_config.camera_info_url.empty() ) {
+        try {
+          // TODO(lucasw) this doesn't throw if the file isn't found,
+          // so will end up with a blank calibration
+          c.validateURL(new_config.camera_info_url);
+          c.loadCameraInfo(new_config.camera_info_url);
+          camera_info_ = c.getCameraInfo();
+        } catch(cv::Exception &e) {
+          NODELET_ERROR("camera calibration failed to load: %s %s %s %i", e.err.c_str(), e.func.c_str(), e.file.c_str(), e.line);
+        }
       }
     }
-    
 
+    if (!initted_ || (new_config.filename != config_.filename)) {
+      try {
+        // TODO(lucasw) dynamic reconfigure option for CV_LOAD_IMAGE_GRAYSCALE,
+        // or keeping format of the source image
+        // TODO(lucasw) if the file doesn't load, keep the old filename
+        original_image_ = cv::imread(new_config.filename, CV_LOAD_IMAGE_COLOR);
+
+        if ( original_image_.empty() ) { // if filename is motion file or device file
+          try {  // if filename is number
+            int num = boost::lexical_cast<int>(new_config.filename);//num is 1234798797
+            cap_.open(num);
+          } catch(boost::bad_lexical_cast &) { // if file name is string
+            cap_.open(new_config.filename);
+          }
+          CV_Assert(cap_.isOpened());
+          cap_.read(original_image_);
+          cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
+        }
+        CV_Assert(!original_image_.empty());
+        image_dirty_ = true;
+      }
+      catch (cv::Exception &e)
+      {
+        NODELET_ERROR("Failed to load image (%s): %s %s %s %i", new_config.filename.c_str(), e.err.c_str(), e.func.c_str(), e.file.c_str(), e.line);
+      }
+
+      // TODO(lucasw) only do this if no camera info was loaded from disk,
+      // or if mismatch between camera info and image width and height.
+      camera_info_.width = original_image_.cols;
+      camera_info_.height = original_image_.rows;
+      camera_info_.distortion_model = "plumb_bob";
+      camera_info_.D = list_of(0)(0)(0)(0)(0).convert_to_container<std::vector<double> >();
+      camera_info_.K = list_of(1)(0)(camera_info_.width/2)(0)(1)(camera_info_.height/2)(0)(0)(1);
+      camera_info_.R = list_of(1)(0)(0)(0)(1)(0)(0)(0)(1);
+      camera_info_.P = list_of(1)(0)(camera_info_.width/2)(0)(0)(1)(camera_info_.height/2)(0)(0)(0)(1)(0);
+    }
+
+    // From http://docs.opencv.org/modules/core/doc/operations_on_arrays.html#void flip(InputArray src, OutputArray dst, int flipCode)
+    // TODO(lucasw) these are implemented wrong below, flip both and flip vertical are swapped.
+    // FLIP_HORIZONTAL == 1, FLIP_VERTICAL == 0 or FLIP_BOTH == -1
+    if (!initted_ || (new_config.flip_horizontal != config_.flip_horizontal) ||
+                     (new_config.flip_vertical != config_.flip_vertical)) {
+      flip_image_ = true;
+      if (new_config.flip_horizontal && new_config.flip_vertical)
+        flip_value_ = 0; // flip both, horizontal and vertical
+      else if (new_config.flip_horizontal)
+        flip_value_ = 1;
+      else if (new_config.flip_vertical)
+        flip_value_ = -1;
+      else
+        flip_image_ = false;
+
+      image_dirty_ = true;
+    }
+
+    config_ = new_config;
   }
 
   void do_work(const ros::TimerEvent& event)
@@ -94,15 +172,16 @@ class ImagePublisherNodelet : public nodelet::Nodelet
     try
     {
       if ( cap_.isOpened() ) {
-        if ( ! cap_.read(image_) ) {
+        if ( ! cap_.read(original_image_) ) {
           cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
+        } else {
+          image_dirty_ = true;
         }
       }
-      if (flip_image_)
-        cv::flip(image_, image_, flip_value_);
+      flip_if_needed();
 
-      sensor_msgs::ImagePtr out_img = cv_bridge::CvImage(std_msgs::Header(), "bgr8", image_).toImageMsg();
-      out_img->header.frame_id = frame_id_;
+      sensor_msgs::ImagePtr out_img = cv_bridge::CvImage(std_msgs::Header(), "bgr8", flipped_image_).toImageMsg();
+      out_img->header.frame_id = config_.frame_id;
       out_img->header.stamp = ros::Time::now();
       camera_info_.header.frame_id = out_img->header.frame_id;
       camera_info_.header.stamp = out_img->header.stamp;
@@ -133,62 +212,13 @@ public:
     it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
     pub_ = image_transport::ImageTransport(nh_).advertiseCamera("image_raw", 1);
 
-    nh_.param("filename", filename_, std::string(""));
-    NODELET_INFO("File name for publishing image is : %s", filename_.c_str());
-    try {
-      image_ = cv::imread(filename_, CV_LOAD_IMAGE_COLOR);
-      if ( image_.empty() ) { // if filename is motion file or device file
-        try {  // if filename is number
-          int num = boost::lexical_cast<int>(filename_);//num is 1234798797
-          cap_.open(num);
-        } catch(boost::bad_lexical_cast &) { // if file name is string
-          cap_.open(filename_);
-        }
-        CV_Assert(cap_.isOpened());
-        cap_.read(image_);
-        cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
-      }
-      CV_Assert(!image_.empty());
-    }
-    catch (cv::Exception &e)
-    {
-      NODELET_ERROR("Failed to load image (%s): %s %s %s %i", filename_.c_str(), e.err.c_str(), e.func.c_str(), e.file.c_str(), e.line);
-    }
-
-    bool flip_horizontal;
-    nh_.param("flip_horizontal", flip_horizontal, false);
-    NODELET_INFO("Flip horizontal image is : %s",  ((flip_horizontal)?"true":"false"));
-
-    bool flip_vertical;
-    nh_.param("flip_vertical", flip_vertical, false);
-    NODELET_INFO("Flip flip_vertical image is : %s", ((flip_vertical)?"true":"false"));
-
-    // From http://docs.opencv.org/modules/core/doc/operations_on_arrays.html#void flip(InputArray src, OutputArray dst, int flipCode)
-    // FLIP_HORIZONTAL == 1, FLIP_VERTICAL == 0 or FLIP_BOTH == -1
-    flip_image_ = true;
-    if (flip_horizontal && flip_vertical)
-      flip_value_ = 0; // flip both, horizontal and vertical
-    else if (flip_horizontal)
-      flip_value_ = 1;
-    else if (flip_vertical)
-      flip_value_ = -1;
-    else
-      flip_image_ = false;
-
-    camera_info_.width = image_.cols;
-    camera_info_.height = image_.rows;
-    camera_info_.distortion_model = "plumb_bob";
-    camera_info_.D = list_of(0)(0)(0)(0)(0).convert_to_container<std::vector<double> >();
-    camera_info_.K = list_of(1)(0)(camera_info_.width/2)(0)(1)(camera_info_.height/2)(0)(0)(1);
-    camera_info_.R = list_of(1)(0)(0)(0)(1)(0)(0)(0)(1);
-    camera_info_.P = list_of(1)(0)(camera_info_.width/2)(0)(0)(1)(camera_info_.height/2)(0)(0)(0)(1)(0);
-
-    timer_ = nh_.createTimer(ros::Duration(1), &ImagePublisherNodelet::do_work, this);
-
     srv.reset(new ReconfigureServer(getPrivateNodeHandle()));
     ReconfigureServer::CallbackType f =
       boost::bind(&ImagePublisherNodelet::reconfigureCallback, this, _1, _2);
     srv->setCallback(f);
+
+    initted_ = true;
+    NODELET_INFO("Initial filename for publishing image is : %s", config_.filename.c_str());
   }
 };
 }


### PR DESCRIPTION
For  #359

Lots of changes needed to make this work.

Handling of camera info urls needs more consideration- if a provided url doesn't work it erases the old one, also a new image loaded erases the loaded camera info url.  What to do if the camera info url width and height don't match the image?  Generate a distortion free camera info of correct size and let the user try again?  I'll add a commit that solves both of those next.

Could consider deprecating providing the filename as a non-ros param arg in the future.

It also looks like flip vertical and flip both are backwards, I didn't fix it here.