### PR TITLE
image_saver: Support lazy subscribing 

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3)
 project(image_view)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS camera_calibration_parsers cv_bridge dynamic_reconfigure image_transport message_filters message_generation nodelet rosconsole roscpp std_srvs stereo_msgs)
 generate_dynamic_reconfigure_options(cfg/ImageView.cfg)

--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -73,7 +73,7 @@ public:
 
   void subscribe()
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
 
     if (subscribing_) return;
     subscribing_ = true;
@@ -94,7 +94,7 @@ public:
 
   void unsubscribe()
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
 
     if (!subscribing_) return;
     subscribing_ = false;
@@ -271,13 +271,13 @@ private:
 
 private:
   boost::format format_;
-  boost::mutex mutex_;
   ros::NodeHandle nh_;
   ros::ServiceServer srv_save_, srv_start_, srv_end_;
   ros::Timer save_timeout_timer_;
   image_transport::ImageTransport it_;
   image_transport::CameraSubscriber sub_camera_;
   image_transport::Subscriber sub_image_;
+  std::mutex mutex_;
   std::string topic_;
   std::string encoding_;
   size_t count_;

--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -144,7 +144,7 @@ public:
         r.sleep();
       }
 
-      if (count != count_)
+      if (count == count_)
       {
         ROS_ERROR("Timed out without saving image");
         return false;

--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -38,7 +38,7 @@
 #include <image_transport/image_transport.h>
 #include <camera_calibration_parsers/parse.h>
 #include <boost/format.hpp>
-#include <boost/thread.hpp>
+#include <thread>
 
 #include <std_srvs/Empty.h>
 #include <std_srvs/Trigger.h>

--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -119,11 +119,13 @@ public:
   bool callbackSave(std_srvs::Empty::Request &req,
                     std_srvs::Empty::Response &res)
   {
+    std::unique_lock<std::mutex> lock(mutex_);
     if (subscribing_)
     {
       ROS_ERROR("Images are already being saved.");
       return false;
     }
+    lock.unlock();
 
     const size_t count = count_;
     should_unsubscribe_ = true;

--- a/image_view/src/nodes/image_saver.cpp
+++ b/image_view/src/nodes/image_saver.cpp
@@ -39,6 +39,7 @@
 #include <camera_calibration_parsers/parse.h>
 #include <boost/format.hpp>
 #include <thread>
+#include <mutex>
 
 #include <std_srvs/Empty.h>
 #include <std_srvs/Trigger.h>


### PR DESCRIPTION
Move from #391 

This pull request includes following updates:
- Support lazy subscribing input topic
- Subscribing image topic to be saved only when saving is requested.
- Add `~wait_for_save` & `~save_timeout` params
  - image_saver has three ways for saving images (though not yet documented)
    - Oneshot save by using `~save service`
    - Durative save by using `~start` & `~end` service
    - Continuous save by setting `~save_all_image` param
  - On oneshot way of saving, call of service `~save` did never return until no image is published from publishers, which can lock calleeforever.
  - With `~wait_for_save` param, we can switch whether calling `~save` request blocks until image is saved or immediately returns from the request just like a non-blocking way.
  - If we choose the `~wait_for_save` as true, then we can set `~save_timeout` param to set timeout for waiting.