### PR TITLE
Enhance calibration of rolling shutter cameras backport melodic->kinetic

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -84,6 +84,9 @@ def main():
                      help="number of radial distortion coefficients to use (up to 6, default %default)")
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
+    group.add_option("--max-chessboard-speed", type="float", default=-1.0,
+                     help="Do not use samples where the calibration pattern is moving faster \
+                     than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
     parser.add_option_group(group)
     options, args = parser.parse_args()
 
@@ -143,7 +146,7 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
-                                 checkerboard_flags=checkerboard_flags)
+                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -92,7 +92,7 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0):
+                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, max_chessboard_speed = -1):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -112,6 +112,7 @@ class CalibrationNode:
         self._checkerboard_flags = checkerboard_flags
         self._pattern = pattern
         self._camera_name = camera_name
+        self._max_chessboard_speed = max_chessboard_speed
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)
@@ -155,10 +156,12 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                        checkerboard_flags=self._checkerboard_flags)
+                                        checkerboard_flags=self._checkerboard_flags,
+                                        max_chessboard_speed = self._max_chessboard_speed)
             else:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                        checkerboard_flags=self.checkerboard_flags)
+                                        checkerboard_flags=self.checkerboard_flags,
+                                        max_chessboard_speed = self._max_chessboard_speed)
 
         # This should just call the MonoCalibrator
         drawable = self.c.handle_msg(msg)
@@ -169,10 +172,12 @@ class CalibrationNode:
         if self.c == None:
             if self._camera_name:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          checkerboard_flags=self._checkerboard_flags,
+                                          max_chessboard_speed = self._max_chessboard_speed)
             else:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._pattern,
-                                          checkerboard_flags=self._checkerboard_flags)
+                                          checkerboard_flags=self._checkerboard_flags,
+                                          max_chessboard_speed = self._max_chessboard_speed)
 
         drawable = self.c.handle_msg(msg)
         self.displaywidth = drawable.lscrib.shape[1] + drawable.rscrib.shape[1]


### PR DESCRIPTION
This pull request aims to improve the calibration accuracy of rolling shutter cameras by avoiding picking frames where the chessboard pattern is moving in the image frame. This should fix #325 .
This is controlled by the --max-chessboard-speed option that allows setting a maximum allowed speed in pixels/frame for the chessboard. If the chessboard is moving faster than the allowed speed, the frame is not picked to be used for calibration.

The chessboard speed is determined by measuring the average distance that each chessboard feature traveled between this and the previous frame.

back-ported from the corresponding melodic PR