### PR TITLE
Add a compressed_image_view app that subscribe to a sensor_msgs/CompressedImage directly

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -63,6 +63,13 @@ target_link_libraries(image_view_exe ${catkin_LIBRARIES}
                                      ${Boost_LIBRARIES}
 )
 
+add_executable(compressed_image_view src/nodes/compressed_image_view.cpp)
+add_dependencies(compressed_image_view ${PROJECT_NAME}_gencfg)
+target_link_libraries(compressed_image_view ${catkin_LIBRARIES}
+                                            ${OpenCV_LIBRARIES}
+                                            ${Boost_LIBRARIES}
+)
+
 add_executable(disparity_view src/nodes/disparity_view.cpp)
 target_link_libraries(disparity_view ${catkin_LIBRARIES}
                                      ${OpenCV_LIBRARIES}
@@ -76,7 +83,7 @@ target_link_libraries(stereo_view ${Boost_LIBRARIES}
                                   ${OpenCV_LIBRARIES}
 )
 
-install(TARGETS disparity_view image_view_exe stereo_view
+install(TARGETS disparity_view image_view_exe compressed_image_view stereo_view
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(FILES nodelet_plugins.xml

--- a/image_view/src/nodes/compressed_image_view.cpp
+++ b/image_view/src/nodes/compressed_image_view.cpp
@@ -1,0 +1,154 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+#include <ros/ros.h>
+#include <sensor_msgs/CompressedImage.h>
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/highgui/highgui.hpp>
+
+#include <boost/format.hpp>
+#include <boost/thread.hpp>
+#include <boost/filesystem.hpp>
+
+int g_count;
+cv::Mat g_last_image;
+boost::format g_filename_format;
+boost::mutex g_image_mutex;
+std::string g_window_name;
+bool g_gui;
+
+void imageCb(const sensor_msgs::CompressedImageConstPtr& msg)
+{
+  boost::mutex::scoped_lock lock(g_image_mutex);
+
+  // Convert to OpenCV native BGR color
+  cv::imdecode(msg->data, cv::IMREAD_UNCHANGED, &g_last_image);
+
+  if (g_gui && !g_last_image.empty()) {
+    const cv::Mat &image = g_last_image;
+    cv::imshow(g_window_name, image);
+    cv::waitKey(1);
+  }
+}
+
+static void mouseCb(int event, int x, int y, int flags, void* param)
+{
+  if (event == cv::EVENT_LBUTTONDOWN) {
+    ROS_WARN_ONCE("Left-clicking no longer saves images. Right-click instead.");
+    return;
+  } else if (event != cv::EVENT_RBUTTONDOWN) {
+    return;
+  }
+
+  boost::mutex::scoped_lock lock(g_image_mutex);
+
+  const cv::Mat &image = g_last_image;
+
+  if (image.empty()) {
+    ROS_WARN("Couldn't save image, no data!");
+    return;
+  }
+
+  std::string filename = (g_filename_format % g_count).str();
+  if (cv::imwrite(filename, image)) {
+    ROS_INFO("Saved image %s", filename.c_str());
+    g_count++;
+  } else {
+    boost::filesystem::path full_path = boost::filesystem::complete(filename);
+    ROS_ERROR_STREAM("Failed to save image. Have permission to write there?: " << full_path);
+  }
+}
+
+static void guiCb(const ros::WallTimerEvent&)
+{
+    // Process pending GUI events and return immediately
+    cv::waitKey(1);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "compressed_image_view", ros::init_options::AnonymousName);
+  if (ros::names::remap("image") == "image") {
+    ROS_WARN("Topic 'image' has not been remapped! Typical command-line usage:\n"
+             "\t$ rosrun image_view compressed_image_view image:=<image topic> [transport]");
+  }
+
+  ros::NodeHandle nh;
+  ros::NodeHandle local_nh("~");
+  ros::WallTimer gui_timer;
+
+  // Default window name is the resolved topic name
+  std::string topic = nh.resolveName("image");
+  local_nh.param("window_name", g_window_name, topic);
+  local_nh.param("gui", g_gui, true);  // gui/no_gui mode
+
+  if (g_gui) {
+    std::string format_string;
+    local_nh.param("filename_format", format_string, std::string("frame%04i.jpg"));
+    g_filename_format.parse(format_string);
+
+    // Handle window size
+    bool autosize;
+    local_nh.param("autosize", autosize, false);
+    cv::namedWindow(g_window_name, autosize ? (cv::WINDOW_AUTOSIZE | cv::WINDOW_KEEPRATIO | cv::WINDOW_GUI_EXPANDED) : 0);
+    cv::setMouseCallback(g_window_name, &mouseCb);
+
+    if(autosize == false)
+    {
+      if(local_nh.hasParam("width") && local_nh.hasParam("height"))
+      {
+        int width;
+        local_nh.getParam("width", width);
+        int height;
+        local_nh.getParam("height", height);
+        cv::resizeWindow(g_window_name, width, height);
+      }
+    }
+
+    // Since cv::startWindowThread() triggers a crash in cv::waitKey()
+    // if OpenCV is compiled against GTK, we call cv::waitKey() from
+    // the ROS event loop periodically, instead.
+    /*cv::startWindowThread();*/
+    gui_timer = local_nh.createWallTimer(ros::WallDuration(0.1), guiCb);
+  }
+
+  ros::Subscriber sub = nh.subscribe(topic, 1, imageCb);
+
+  ros::spin();
+
+  if (g_gui) {
+    cv::destroyWindow(g_window_name);
+  }
+  return 0;
+}


### PR DESCRIPTION
Useful for node that directly publishes compressed image without image_transport