### PR TITLE
Avoid crashing when the x or y offset is too large

### DIFF
--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -195,8 +195,22 @@ void CropDecimateNodelet::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
     config.height &= ~0x1;    
   }
 
+  // TODO(lucasw) should generate a black image where there isn't any source image,
+  // could be a dynamic reconfigure option
   int max_width = image_msg->width - config.x_offset;
+  if (max_width <= 0)
+  {
+    ROS_DEBUG_STREAM("x offset is outside the input image width: "
+        << image_msg->width << ", x offset: " << config.x_offset);
+    return;
+  }
   int max_height = image_msg->height - config.y_offset;
+  if (max_height <= 0)
+  {
+    ROS_DEBUG_STREAM("y offset is outside the input image height: "
+        << image_msg->height << ", y offset: " << config.y_offset);
+    return;
+  }
   int width = config.width;
   int height = config.height;
   if (width == 0 || width > max_width)

--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -195,6 +195,8 @@ void CropDecimateNodelet::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
     config.height &= ~0x1;    
   }
 
+  // TODO(lucasw) need to incorporate the x_offset and y_offset within info_msg
+
   // TODO(lucasw) should generate a black image where there isn't any source image,
   // could be a dynamic reconfigure option
   int max_width = image_msg->width - config.x_offset;

--- a/image_proc/src/nodelets/crop_decimate.cpp
+++ b/image_proc/src/nodelets/crop_decimate.cpp
@@ -195,21 +195,17 @@ void CropDecimateNodelet::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
     config.height &= ~0x1;    
   }
 
-  // TODO(lucasw) need to incorporate the x_offset and y_offset within info_msg
-
-  // TODO(lucasw) should generate a black image where there isn't any source image,
-  // could be a dynamic reconfigure option
   int max_width = image_msg->width - config.x_offset;
   if (max_width <= 0)
   {
-    ROS_DEBUG_STREAM("x offset is outside the input image width: "
+    ROS_WARN_STREAM("x offset is outside the input image width: "
         << image_msg->width << ", x offset: " << config.x_offset);
     return;
   }
   int max_height = image_msg->height - config.y_offset;
   if (max_height <= 0)
   {
-    ROS_DEBUG_STREAM("y offset is outside the input image height: "
+    ROS_WARN_STREAM("y offset is outside the input image height: "
         << image_msg->height << ", y offset: " << config.y_offset);
     return;
   }


### PR DESCRIPTION
Later should make it optional to create blank image where there is no source image to be had.

Also later need to respect the camera info roi of the incoming image, the crop coordinates should be relative to the uncropped incoming image, not the cropped one.