### PR TITLE
Expand range for min_disparity and disparity_range.

### DIFF
--- a/stereo_image_proc/cfg/Disparity.cfg
+++ b/stereo_image_proc/cfg/Disparity.cfg
@@ -19,8 +19,8 @@ gen.add("prefilter_cap",  int_t, 0, "Bound on normalized pixel values", 31, 1, 6
 
 # disparity block matching correlation parameters
 gen.add("correlation_window_size", int_t, 0, "SAD correlation window width, pixels", 15, 5, 255)
-gen.add("min_disparity",           int_t, 0, "Disparity to begin search at, pixels (may be negative)", 0, -128, 128)
-gen.add("disparity_range",         int_t, 0, "Number of disparities to search, pixels", 64, 32, 256)
+gen.add("min_disparity",           int_t, 0, "Disparity to begin search at, pixels (may be negative)", 0, -2048, 2048)
+gen.add("disparity_range",         int_t, 0, "Number of disparities to search, pixels", 64, 32, 4096)
 # TODO What about trySmallerWindows?
 
 # disparity block matching post-filtering parameters


### PR DESCRIPTION
This provides a much greater limits for min_disparity and disparity_range in Disparity.cfg. I would have preferred to remove the limits completely, but that makes for ugly/useless slider bars in rqt_reconfigure (the text entry box besides the slider would remain usable).