### PR TITLE
camera_calibration: Fix excessive CPU usage due to queue synchronization

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -68,6 +68,9 @@ def main():
     group.add_option("--no-service-check",
                      action="store_false", dest="service_check", default=True,
                      help="disable check for set_camera_info services at startup")
+    group.add_option("--queue-size",
+                     type="int", default=1,
+                     help="image queue size (default %default, set to 0 for unlimited)")
     parser.add_option_group(group)
     group = OptionGroup(parser, "Calibration Optimizer Options")
     group.add_option("--fix-principal-point",
@@ -146,7 +149,8 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
-                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed)
+                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
+                                 queue_size=options.queue_size)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -52,6 +52,9 @@ class BufferQueue(Queue):
     when adding an item and the queue is full.
     """
     def put(self, item, *args, **kwargs):
+        # The base implementation, for reference:
+        # https://github.com/python/cpython/blob/2.7/Lib/Queue.py#L107
+        # https://github.com/python/cpython/blob/3.8/Lib/queue.py#L121
         with self.mutex:
             if self.maxsize > 0 and self._qsize() == self.maxsize:
                 self._get()

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -40,12 +40,24 @@ import rospy
 import sensor_msgs.msg
 import sensor_msgs.srv
 import threading
-import time
-from camera_calibration.calibrator import MonoCalibrator, StereoCalibrator, ChessboardInfo, Patterns
-from collections import deque
-from message_filters import ApproximateTimeSynchronizer
-from std_msgs.msg import String
-from std_srvs.srv import Empty
+from camera_calibration.calibrator import MonoCalibrator, StereoCalibrator, Patterns
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
+
+
+class BufferQueue(Queue):
+    """Slight modification of the standard Queue that discards the oldest item
+    when adding an item and the queue is full.
+    """
+    def put(self, item, *args, **kwargs):
+        with self.mutex:
+            if self.maxsize > 0 and self._qsize() == self.maxsize:
+                self._get()
+            self._put(item)
+            self.unfinished_tasks += 1
+            self.not_empty.notify()
 
 
 class DisplayThread(threading.Thread):
@@ -65,10 +77,7 @@ class DisplayThread(threading.Thread):
         cv2.setMouseCallback("display", self.opencv_calibration_node.on_mouse)
         cv2.createTrackbar("scale", "display", 0, 100, self.opencv_calibration_node.on_scale)
         while True:
-            # wait for an image (could happen at the very beginning when the queue is still empty)
-            while len(self.queue) == 0:
-                time.sleep(0.1)
-            im = self.queue[0]
+            im = self.queue.get()
             cv2.imshow("display", im)
             k = cv2.waitKey(6) & 0xFF
             if k in [27, ord('q')]:
@@ -84,15 +93,14 @@ class ConsumerThread(threading.Thread):
 
     def run(self):
         while True:
-            # wait for an image (could happen at the very beginning when the queue is still empty)
-            while len(self.queue) == 0:
-                time.sleep(0.1)
-            self.function(self.queue[0])
+            m = self.queue.get()
+            self.function(m)
 
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, max_chessboard_speed = -1):
+                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, max_chessboard_speed = -1,
+                 queue_size = 1):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -128,8 +136,8 @@ class CalibrationNode:
         self.set_right_camera_info_service = rospy.ServiceProxy("%s/set_camera_info" % rospy.remap_name("right_camera"),
                                                                 sensor_msgs.srv.SetCameraInfo)
 
-        self.q_mono = deque([], 1)
-        self.q_stereo = deque([], 1)
+        self.q_mono = BufferQueue(queue_size)
+        self.q_stereo = BufferQueue(queue_size)
 
         self.c = None
 
@@ -147,10 +155,10 @@ class CalibrationNode:
         pass
 
     def queue_monocular(self, msg):
-        self.q_mono.append(msg)
+        self.q_mono.put(msg)
 
     def queue_stereo(self, lmsg, rmsg):
-        self.q_stereo.append((lmsg, rmsg))
+        self.q_stereo.put((lmsg, rmsg))
 
     def handle_monocular(self, msg):
         if self.c == None:
@@ -226,7 +234,7 @@ class OpenCVCalibrationNode(CalibrationNode):
 
         CalibrationNode.__init__(self, *args, **kwargs)
 
-        self.queue_display = deque([], 1)
+        self.queue_display = BufferQueue(maxsize=1)
         self.display_thread = DisplayThread(self.queue_display, self)
         self.display_thread.setDaemon(True)
         self.display_thread.start()
@@ -316,7 +324,7 @@ class OpenCVCalibrationNode(CalibrationNode):
                 #print "linear", linerror
             self.putText(display, msg, (width, self.y(1)))
 
-        self.queue_display.append(display)
+        self.queue_display.put(display)
 
     def redraw_stereo(self, drawable):
         height = drawable.lscrib.shape[0]
@@ -354,4 +362,4 @@ class OpenCVCalibrationNode(CalibrationNode):
                 self.putText(display, "dim", (2 * width, self.y(2)))
                 self.putText(display, "%.3f" % drawable.dim, (2 * width, self.y(3)))
 
-        self.queue_display.append(display)
+        self.queue_display.put(display)


### PR DESCRIPTION
I was getting near 100% CPU usage with cameracalibrator.py even if no images (after then inital one) are being received and no actual processing is taking place.

This appeared to be caused by the queue synchronization code doing 
```python
while len(self.queue) == 0:
    time.sleep(0.1)
```
to wait for incoming images. This does not look too unreasonable, but replacing it with proper thread synchronization via locks fixed the excessive CPU usage.

Specifically, I replaced the deque with a slightly modified standard Queue that drops the oldest item instead of raising an exception when adding an item to an already full queue, just like deque. Queue also uses deque internally anyway, so in that sense the performance should be the same.

I also added a `--queue-size` parameter to allow adjustment of the max queue size. I found this useful when calibrating with images from a bag, where you want to use all available frames and set the playback rate as high as possible.

Relates to #112 and #121.