### PR TITLE
camera_calibration: Make sure 'calibrate' button works even if not receiving images anymore

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -40,6 +40,7 @@ import rospy
 import sensor_msgs.msg
 import sensor_msgs.srv
 import threading
+import time
 from camera_calibration.calibrator import MonoCalibrator, StereoCalibrator, Patterns
 try:
     from queue import Queue
@@ -74,19 +75,23 @@ class DisplayThread(threading.Thread):
         threading.Thread.__init__(self)
         self.queue = queue
         self.opencv_calibration_node = opencv_calibration_node
+        self.image = None
 
     def run(self):
         cv2.namedWindow("display", cv2.WINDOW_NORMAL)
         cv2.setMouseCallback("display", self.opencv_calibration_node.on_mouse)
         cv2.createTrackbar("scale", "display", 0, 100, self.opencv_calibration_node.on_scale)
         while True:
-            im = self.queue.get()
-            cv2.imshow("display", im)
+            if self.queue.qsize() > 0:
+                self.image = self.queue.get()
+                cv2.imshow("display", self.image)
+            else:
+                time.sleep(0.1)
             k = cv2.waitKey(6) & 0xFF
             if k in [27, ord('q')]:
                 rospy.signal_shutdown('Quit')
-            elif k == ord('s'):
-                self.opencv_calibration_node.screendump(im)
+            elif k == ord('s') and self.image is not None:
+                self.opencv_calibration_node.screendump(self.image)
 
 class ConsumerThread(threading.Thread):
     def __init__(self, queue, function):
@@ -143,6 +148,8 @@ class CalibrationNode:
         self.q_stereo = BufferQueue(queue_size)
 
         self.c = None
+        
+        self._last_display = None
 
         mth = ConsumerThread(self.q_mono, self.handle_monocular)
         mth.setDaemon(True)
@@ -254,7 +261,10 @@ class OpenCVCalibrationNode(CalibrationNode):
         if event == cv2.EVENT_LBUTTONDOWN and self.displaywidth < x:
             if self.c.goodenough:
                 if 180 <= y < 280:
+                    print("**** Calibrating ****")
                     self.c.do_calibration()
+                    self.buttons(self._last_display)
+                    self.queue_display.put(self._last_display)
             if self.c.calibrated:
                 if 280 <= y < 380:
                     self.c.do_save()
@@ -293,6 +303,7 @@ class OpenCVCalibrationNode(CalibrationNode):
         while os.access("/tmp/dump%d.png" % i, os.R_OK):
             i += 1
         cv2.imwrite("/tmp/dump%d.png" % i, im)
+        print("Saved screen dump to /tmp/dump%d.png" % i)
 
     def redraw_monocular(self, drawable):
         height = drawable.scrib.shape[0]
@@ -301,7 +312,6 @@ class OpenCVCalibrationNode(CalibrationNode):
         display = numpy.zeros((max(480, height), width + 100, 3), dtype=numpy.uint8)
         display[0:height, 0:width,:] = drawable.scrib
         display[0:height, width:width+100,:].fill(255)
-
 
         self.buttons(display)
         if not self.c.calibrated:
@@ -327,6 +337,7 @@ class OpenCVCalibrationNode(CalibrationNode):
                 #print "linear", linerror
             self.putText(display, msg, (width, self.y(1)))
 
+        self._last_display = display
         self.queue_display.put(display)
 
     def redraw_stereo(self, drawable):
@@ -365,4 +376,5 @@ class OpenCVCalibrationNode(CalibrationNode):
                 self.putText(display, "dim", (2 * width, self.y(2)))
                 self.putText(display, "%.3f" % drawable.dim, (2 * width, self.y(3)))
 
+        self._last_display = display
         self.queue_display.put(display)


### PR DESCRIPTION
Mouse events are currently only being checked and the buttons being enabled/disabled when the display gets redrawn on received images.
This change allows the calibration to be saved even when there are no more images in the queue, e.g. when a bag playback has finished.