### PR TITLE
Add image_proc with GPU support

### DIFF
--- a/image_proc_tegra/CMakeLists.txt
+++ b/image_proc_tegra/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(image_proc_tegra)
+set (CMAKE_CXX_STANDARD 11)
+
+find_package(CUDA REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  cv_bridge
+  image_transport
+  image_geometry
+  OpenCV
+  sensor_msgs
+  std_msgs
+  roscpp
+  nodelet  
+)
+
+catkin_package(
+  CATKIN_DEPENDS image_geometry roscpp sensor_msgs
+  DEPENDS OpenCV
+  LIBRARIES ${PROJECT_NAME}
+)
+
+include_directories(SYSTEM 
+${catkin_INCLUDE_DIRS} 
+${OpenCV_INCLUDE_DIRS}
+${CUDA_INCLUDE_DIRS}
+)
+include_directories(include)
+
+add_library(${PROJECT_NAME}     src/nodelets/rectify.cpp )
+target_link_libraries(${PROJECT_NAME}
+${catkin_LIBRARIES}
+${OpenCV_LIBRARIES}
+${CUDA_LIBRARIES}
+)
+
+add_executable(image_proc_tegra_exe src/image_proc_tegra.cpp)
+
+target_link_libraries(image_proc_tegra_exe
+   ${PROJECT_NAME}
+   ${catkin_LIBRARIES}
+)

--- a/image_proc_tegra/nodelet_plugins.xml
+++ b/image_proc_tegra/nodelet_plugins.xml
@@ -1,0 +1,20 @@
+<library path="libimage_proc_tegra">
+  
+   <class name="image_proc_tegra/RectifyNodelet"
+	  type="image_proc_tegra::RectifyNodelet"
+	  base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to rectify an unrectified camera image stream using gpu
+    </description>
+  </class>
+  
+  <class name="image_proc_tegra_fisheye/RectifyNodelet"
+	 type="image_proc_tegra_fisheye::RectifyNodelet"
+	 base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to rectify an unrectified fisheyecamera image stream using gpu
+    </description>
+  </class>
+  
+  
+</library>

--- a/image_proc_tegra/package.xml
+++ b/image_proc_tegra/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<package>
+  <name>image_proc_tegra</name>
+  <version>0.0.1</version>
+  <description>Uses OpenCV gpu functions for camera calibration</description>
+
+  <maintainer email="jak000@gmail.com">Jack Qiao</maintainer>
+  <license>BSD</license>
+
+  <url type="website">https://github.com/Jack000</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>OpenCV</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>image_geometry</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>boost</build_depend>
+  
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>OpenCV</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>image_geometry</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>roscpp</run_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
+</package>

--- a/image_proc_tegra/readme.md
+++ b/image_proc_tegra/readme.md
@@ -1,0 +1,54 @@
+# image_proc_tegra
+
+A ROS nodelet for image rectification using OpenCV's gpu functions. This nodelet is useful to reduce CPU usage in rectifying large video streams.
+Needs OpenCV 3.4 with CUDA support
+
+
+Install:
+
+```
+cd ~/catkin_ws/src
+git clone https://github.com/DavidTorresOcana/image_pipeline
+catkin_make
+```
+
+same topics as image_proc:
+
+```
+Subscribed topics:
+  ~camera_info
+  ~image_raw
+
+Published topics:
+  ~image_rect
+```
+
+## Nodelets 
+### image_proc_tegra
+Rectification with standard calibration method as in image_proc
+
+example launch file:
+
+```
+  <!-- nodelet manager from image stream -->
+  <node pkg="nodelet" type="nodelet" name="image_proc_tegra"  args="manager" />
+  
+  <node pkg="nodelet" type="nodelet" name="image_proc_test" args="load image_proc_tegra/RectifyNodelet camera_nodelet_manager" output="screen">
+    <remap from="camera_info" to="/camera/color/camera_info" />
+    <remap from="image_raw" to="/camera/color/image_raw" />
+    <remap from="image_rect" to="/camera/color/image_rect" />
+  </node>
+```
+### image_proc_tegra_fisheye
+Rectification using OpenCV 3 fisheye camera rectification implementation. Works with any camera that was rectifies using camera_calibration_fisheye (https://github.com/DavidTorresOcana/image_pipeline/tree/indigo/camera_calibration_fisheye)
+
+example launch file:
+```
+  <!-- nodelet manager from image stream -->
+  <node pkg="nodelet" type="nodelet" name="image_proc_tegra_fisheye"  args="manager" />
+  <node pkg="nodelet" type="nodelet" name="image_proc_test" args="load image_proc_tegra_fisheye/RectifyNodelet camera_nodelet_manager" output="screen">
+    <remap from="camera_info" to="/camera/color/camera_info" />
+    <remap from="image_raw" to="/camera/color/image_raw" />
+    <remap from="image_rect" to="/camera/color/image_rect" />
+  </node>
+```

--- a/image_proc_tegra/src/image_proc_tegra.cpp
+++ b/image_proc_tegra/src/image_proc_tegra.cpp
@@ -1,0 +1,14 @@
+#include "ros/ros.h"
+#include "nodelet/loader.h"
+
+int main(int argc, char **argv){
+  ros::init(argc, argv, "image_proc_tegra");
+  nodelet::Loader nodelet;
+  nodelet::M_string remap(ros::names::getRemappings());
+  nodelet::V_string nargv;
+  std::string nodelet_name = ros::this_node::getName();
+  
+  nodelet.load(nodelet_name, nodelet_name + "/RectifyNodelet", remap, nargv);
+  ros::spin();
+  return 0;
+}

--- a/image_proc_tegra/src/nodelets/rectify.cpp
+++ b/image_proc_tegra/src/nodelets/rectify.cpp
@@ -1,0 +1,121 @@
+#include "ros/ros.h"
+#include "rectify.h"
+
+#include <cuda_runtime_api.h>
+#include <cuda.h>
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(image_proc_tegra::RectifyNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(image_proc_tegra_fisheye::RectifyNodelet, nodelet::Nodelet)
+
+
+namespace image_proc_tegra {
+  void RectifyNodelet::onInit(){
+    ros::NodeHandle &nh = getNodeHandle();
+    camera_set_=false;
+    sub_ = nh.subscribe("image_raw", 5, &RectifyNodelet::process_image, this);
+    sub_info_ = nh.subscribe("camera_info", 5, &RectifyNodelet::camera_info, this);
+    pub_ = nh.advertise<sensor_msgs::Image>("image_rect", 10);
+  };
+
+  void RectifyNodelet::process_image(const sensor_msgs::ImageConstPtr& frame){
+    if(!camera_set_){
+      return;
+    }
+    cv_bridge::CvImageConstPtr image = cv_bridge::toCvShare(frame);
+    cv::cuda::GpuMat image_gpu(image->image);
+    cv::cuda::GpuMat image_gpu_rect(cv::Size(image->image.rows, image->image.cols), image->image.type());
+    cv::cuda::remap(image_gpu, image_gpu_rect, mapx_, mapy_, cv::INTER_CUBIC, cv::BORDER_CONSTANT);
+    cv::Mat image_rect = cv::Mat(image_gpu_rect);
+
+    cv_bridge::CvImage out_msg;
+    out_msg.header   = frame->header;
+    out_msg.encoding = frame->encoding;
+    out_msg.image  = image_rect;
+    pub_.publish(out_msg.toImageMsg());
+  } 
+
+  void RectifyNodelet::camera_info(const sensor_msgs::CameraInfoConstPtr& info_msg){
+    image_geometry::PinholeCameraModel camera;
+    camera.fromCameraInfo(info_msg);
+    cv::Mat m1;
+    cv::Mat m2;
+    cv::initUndistortRectifyMap(camera.intrinsicMatrix(), camera.distortionCoeffs(), cv::Mat(), camera.intrinsicMatrix(), camera.fullResolution(), CV_32FC1, m1, m2);
+    mapx_ = cv::cuda::GpuMat(m1);
+    mapy_ = cv::cuda::GpuMat(m2);
+    sub_info_.shutdown();
+    camera_set_ = true;
+  }
+} // namespace
+
+namespace image_proc_tegra_fisheye {
+  void RectifyNodelet::onInit(){
+    ros::NodeHandle &nh = getNodeHandle();
+    camera_set_ = false;
+    
+    // ROS params
+    ros::param::get(ros::this_node::getName()+"/img_downsample", img_downsample);
+    ros::param::get(ros::this_node::getName()+"/img_downsample_width", img_downsample_width);
+    ros::param::get(ros::this_node::getName()+"/img_downsample_height", img_downsample_height);
+    
+    sub_ = nh.subscribe("image_raw", 5, &RectifyNodelet::process_image, this);
+    sub_info_ = nh.subscribe("camera_info", 5, &RectifyNodelet::camera_info, this);
+    pub_ = nh.advertise<sensor_msgs::Image>("image_rect", 10);
+  };
+  
+  void RectifyNodelet::process_image(const sensor_msgs::ImageConstPtr& frame){
+    if(!camera_set_){
+      return;
+    }
+    cv_bridge::CvImageConstPtr image = cv_bridge::toCvShare(frame);
+    cv::cuda::GpuMat image_gpu, image_gpu_rect ;
+    
+    // upload to GPU
+    image_gpu.upload( image->image );
+    
+    
+    //cv::cuda::remap(image_gpu, image_gpu_rect, mapx_, mapy_, cv::INTER_LINEAR, cv::BORDER_CONSTANT);
+    cv::cuda::remap(image_gpu, image_gpu_rect, mapx_, mapy_, cv::INTER_CUBIC, cv::BORDER_CONSTANT);
+    
+    // Resize? maybe to increase resolution
+    if(img_downsample){
+        cv::cuda::resize(image_gpu_rect , image_gpu_rect, cv::Size(img_downsample_width, img_downsample_height) , 0.0, 0.0, cv::INTER_CUBIC);
+    }
+    cv::Mat image_rect;
+    image_gpu_rect.download( image_rect );
+    
+    // CPU only
+    //cv::Mat image_rect( image->image );
+    //cv::remap(image_rect, image_rect, mx, my, cv::INTER_LANCZOS4, cv::BORDER_CONSTANT);
+    //cv::resize(image_rect , image_rect, cv::Size(800, 503) , 0.0, 0.0, cv::INTER_LANCZOS4);
+    
+    cv_bridge::CvImage out_msg;
+    out_msg.header   = frame->header;
+    out_msg.encoding = frame->encoding;
+    out_msg.image  = image_rect;
+    pub_.publish(out_msg.toImageMsg());
+	
+	// Deallocate GPU memory:
+	//cudaFree(image_gpu.data);
+	//cudaFree(image_gpu_rect.data);
+  }
+
+  void RectifyNodelet::camera_info(const sensor_msgs::CameraInfoConstPtr& info_msg){
+    image_geometry::PinholeCameraModel camera;
+    
+    camera.fromCameraInfo(info_msg);
+    cv::Mat m1; 
+    cv::Mat m2;
+    
+    //cv::fisheye::initUndistortRectifyMap(camera.intrinsicMatrix(), camera.distortionCoeffs(), cv::Mat(), camera.intrinsicMatrix(), camera.fullResolution(), CV_32FC1, m1, m2); 
+
+    // Try  with rotation matrix for proper alignment of Stereo pairs
+    cv::fisheye::initUndistortRectifyMap(camera.intrinsicMatrix(), camera.distortionCoeffs(), camera.rotationMatrix(), camera.intrinsicMatrix() , camera.fullResolution(), CV_32FC1, m1, m2);
+    
+    mapx_ = cv::cuda::GpuMat(m1);
+    mapy_ = cv::cuda::GpuMat(m2);
+    
+    sub_info_.shutdown();
+    camera_set_ = true;
+  }
+} // namespace

--- a/image_proc_tegra/src/nodelets/rectify.h
+++ b/image_proc_tegra/src/nodelets/rectify.h
@@ -1,0 +1,65 @@
+#include <nodelet/nodelet.h>
+#include "ros/ros.h"
+#include <image_transport/image_transport.h>
+
+
+#include "opencv2/opencv.hpp"
+#include "opencv2/core.hpp"
+#include "opencv2/highgui.hpp"
+#include <opencv2/cudacodec.hpp>
+
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <image_geometry/pinhole_camera_model.h>
+
+namespace image_proc_tegra
+{
+
+    class RectifyNodelet : public nodelet::Nodelet
+    {
+        public:
+            virtual void onInit();
+            void process_image(const sensor_msgs::ImageConstPtr& frame);
+            void camera_info(const sensor_msgs::CameraInfoConstPtr& info_msg);
+        private:
+            ros::Subscriber sub_;
+            ros::Subscriber sub_info_;
+            ros::Publisher pub_;
+            cv::cuda::GpuMat mapx_;
+            cv::cuda::GpuMat mapy_;
+            bool camera_set_;
+    };
+
+}
+
+namespace image_proc_tegra_fisheye
+{
+
+    class RectifyNodelet : public nodelet::Nodelet
+    {
+        public:
+            virtual void onInit();
+            void process_image(const sensor_msgs::ImageConstPtr& frame);
+            void camera_info(const sensor_msgs::CameraInfoConstPtr& info_msg);
+        private:
+            ros::Subscriber sub_;
+            ros::Subscriber sub_info_;
+            ros::Publisher pub_;
+            cv::cuda::GpuMat mapx_;
+            cv::cuda::GpuMat mapy_;
+            
+            cv::Mat mx;
+            cv::Mat my;
+            
+     
+            bool camera_set_;
+            
+            bool img_downsample = false;
+            int img_downsample_width = 800;
+            int img_downsample_height = 503;
+            
+            
+    };
+
+}
+


### PR DESCRIPTION
* image_proc_tegra(https://github.com/DavidTorresOcana/image_pipeline/tree/indigo/image_proc_tegra): 
    - A camera rectification package for camera rectification with OpenCV >3 and CUDA support. Tested in Tegra cores. Faster than image_proc since it uses CUDA for rectification

   - It also implements a Nodelet for Fisheye cameras rectification, if calibrated with camera_calibration_fisheye(https://github.com/DavidTorresOcana/image_pipeline/tree/indigo/camera_calibration_fisheye). It uses OpenCV >3  with CUDA suport