### PR TITLE
Support MONO16 and 32FC1 depth in rectification

### DIFF
--- a/image_proc/src/libimage_proc/processor.cpp
+++ b/image_proc/src/libimage_proc/processor.cpp
@@ -53,6 +53,12 @@ bool Processor::process(const sensor_msgs::ImageConstPtr& raw_image,
   if (raw_encoding == enc::BGR8 || raw_encoding == enc::RGB8) {
     raw_type = CV_8UC3;
     output.color_encoding = raw_encoding;
+  } else if (raw_encoding == enc::TYPE_32FC1) {
+    // Float depth
+    raw_type = CV_32FC1;
+  } else if (raw_encoding == enc::MONO16) {
+    // Uint16 depth
+    raw_type = CV_16UC1;
   }
   // Construct cv::Mat pointing to raw_image data
   const cv::Mat raw(raw_image->height, raw_image->width, raw_type,
@@ -98,6 +104,14 @@ bool Processor::process(const sensor_msgs::ImageConstPtr& raw_image,
     output.mono = raw;
     if (flags & COLOR_EITHER) {
       output.color_encoding = enc::MONO8;
+      output.color = raw;
+    }
+  }
+  // Depth
+  else if (raw_encoding == enc::TYPE_32FC1 || raw_encoding == enc::MONO16) {
+    output.mono = raw;
+    if (flags & COLOR_EITHER) {
+      output.color_encoding = raw_encoding
       output.color = raw;
     }
   }

--- a/image_proc/src/libimage_proc/processor.cpp
+++ b/image_proc/src/libimage_proc/processor.cpp
@@ -111,7 +111,7 @@ bool Processor::process(const sensor_msgs::ImageConstPtr& raw_image,
   else if (raw_encoding == enc::TYPE_32FC1 || raw_encoding == enc::MONO16) {
     output.mono = raw;
     if (flags & COLOR_EITHER) {
-      output.color_encoding = raw_encoding
+      output.color_encoding = raw_encoding;
       output.color = raw;
     }
   }

--- a/image_proc/src/nodelets/debayer.cpp
+++ b/image_proc/src/nodelets/debayer.cpp
@@ -123,7 +123,7 @@ void DebayerNodelet::imageCb(const sensor_msgs::ImageConstPtr& raw_msg)
   // First publish to mono if needed
   if (pub_mono_.getNumSubscribers())
   {
-    if (enc::isMono(raw_msg->encoding))
+    if (enc::isMono(raw_msg->encoding) || raw_msg->encoding == enc::TYPE_32FC1)
       pub_mono_.publish(raw_msg);
     else
     {
@@ -156,7 +156,7 @@ void DebayerNodelet::imageCb(const sensor_msgs::ImageConstPtr& raw_msg)
   if (!pub_color_.getNumSubscribers())
     return;
 
-  if (enc::isMono(raw_msg->encoding))
+  if (enc::isMono(raw_msg->encoding) || raw_msg->encoding == enc::TYPE_32FC1)
   {
     // For monochrome, no processing needed!
     pub_color_.publish(raw_msg);


### PR DESCRIPTION
This change enables to rectify depth images in mono16 and float32 formats. Non stereo sensors such as ToF cameras typically publish depth in distorted coordinate frames.