### PR TITLE
adding option to independently calibrate mono cameras before a stereo cal

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -108,7 +108,8 @@ def main():
     group.add_option("--max-chessboard-speed", type="float", default=-1.0,
                      help="Do not use samples where the calibration pattern is moving faster \
                      than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
-
+    group.add_option("--mono-before-stereo", action='store_true', default=False,
+                     help="Independently perform monocular calibration before stereo calibration")
     parser.add_option_group(group)
 
     options, args = parser.parse_args()
@@ -191,7 +192,7 @@ def main():
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, fisheye_calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
-                                 queue_size=options.queue_size)
+                                 queue_size=options.queue_size, mono_before_stereo=options.mono_before_stereo)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -915,6 +915,8 @@ class StereoCalibrator(Calibrator):
     def __init__(self, *args, **kwargs):
         if 'name' not in kwargs:
             kwargs['name'] = 'narrow_stereo'
+        self.lcal = kwargs.pop('lcal', None)
+        self.rcal = kwargs.pop('rcal', None)
         super(StereoCalibrator, self).__init__(*args, **kwargs)
         self.l = MonoCalibrator(*args, **kwargs)
         self.r = MonoCalibrator(*args, **kwargs)
@@ -955,10 +957,26 @@ class StereoCalibrator(Calibrator):
 
     def cal_fromcorners(self, good):
         # Perform monocular calibrations
-        lcorners = [(l, b) for (l, r, b) in good]
-        rcorners = [(r, b) for (l, r, b) in good]
-        self.l.cal_fromcorners(lcorners)
-        self.r.cal_fromcorners(rcorners)
+        if self.lcal and self.rcal:
+            self.lcal.do_calibration()
+            self.rcal.do_calibration()
+            self.l.intrinsics = self.lcal.intrinsics
+            self.l.distortion = self.lcal.distortion
+            self.r.intrinsics = self.rcal.intrinsics
+            self.r.distortion = self.rcal.distortion
+            self.l.R = self.lcal.R
+            self.r.R = self.rcal.R
+            self.l.P = self.lcal.P
+            self.r.P = self.rcal.P
+            self.l.mapx = self.lcal.mapx
+            self.l.mapy = self.lcal.mapy
+            self.r.mapx = self.rcal.mapx
+            self.r.mapy = self.rcal.mapy
+        else:
+            lcorners = [(l, b) for (l, r, b) in good]
+            rcorners = [(r, b) for (l, r, b) in good]
+            self.l.cal_fromcorners(lcorners)
+            self.r.cal_fromcorners(rcorners)
 
         lipts = [ l for (l, _, _) in good ]
         ripts = [ r for (_, r, _) in good ]


### PR DESCRIPTION
Adds an optional flag to allow user to do a good monocular calibration of each camera of a stereo pair independently, then fix those values for the stereo calibration between them, with the `--mono-before-stereo` flag. 

Currently, each camera is independently calibrated, using *only* the corners that were valid for both cameras during the stereo data collection. For wider baselines, this means that the non-overlapping portions of each camera's image will have no valid data but will still be used to overwrite any existing monocular calibration.

One option to address this would be to also listen for `camera_info` messages and provide a flag to use that intrinsic information for the stereo calibration.

This PR instead combines the 3 calibration processes into one; first, data for the left mono camera is collected, then the right mono camera, and finally the stereo pair. The UI updates for each step; and the monocular calibrations are deferred until the end to save the user lots of time waiting for each mono to complete.

I have tested this primarily on version 1.12.23 with ROS melodic, and have seen some lagginess issues using the `--approximate` flag on version 1.13.0, but I don't see how it would be related to these changes.