### PR TITLE
Provide include directory for harfbuzz

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -42,6 +42,10 @@ find_package(GTK2)
 add_definitions(-DHAVE_GTK)
 include_directories(${GTK2_INCLUDE_DIRS})
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_HB REQUIRED harfbuzz)
+include_directories(${PC_HB_INCLUDE_DIRS})
+
 # Nodelet library
 add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nodelet.cpp src/nodelets/window_thread.cpp)
 target_link_libraries(image_view ${catkin_LIBRARIES}


### PR DESCRIPTION
This resolves #456 . Changes to the latest pango release resulted in issues linking to harfbuzz headers. See: https://gitlab.gnome.org/GNOME/pango/issues/387.

Not sure if the solution presented in this PR is the best one, but it fixes the build. Here is a potential alternative solution: https://gitlab.com/Remmina/Remmina/commit/32adac791b8d112a8d618ef770326674092f5af7

See #456 for more information.