### PR TITLE
ROS2 port of crop decimate in image proc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
           name: Build
           command: |
             source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
-            colcon build --parallel-workers 4
+            colcon build --parallel-workers 2
       - run:
           name: Run Tests
           command: |
             source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
-            colcon test --parallel-workers 4
+            colcon test --parallel-workers 2
             colcon test-result
 
 workflows:

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -76,6 +76,20 @@ ament_target_dependencies(resize
 rclcpp_components_register_nodes(resize "image_proc::ResizeNode")
 set(node_plugins "${node_plugins}image_proc::ResizeNode;$<TARGET_FILE:resize>\n")
 
+add_library(crop_decimate SHARED
+  src/crop_decimate.cpp
+  )
+
+target_compile_definitions(crop_decimate
+  PRIVATE "COMPOSITION_BUILDING_DLL")
+
+ament_target_dependencies(crop_decimate
+  ${dependencies}
+)
+
+rclcpp_components_register_nodes(crop_decimate "image_proc::CropDecimateNode")
+set(node_plugins "${node_plugins}image_proc::CropDecimateNode;$<TARGET_FILE:crop_decimate>\n")
+
 add_executable(image_proc
                src/image_proc.cpp
 )
@@ -106,6 +120,13 @@ install(
   RUNTIME DESTINATION bin
 )
 install(
+  TARGETS crop_decimate
+  EXPORT export_resize
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(
   TARGETS debayer
   EXPORT export_debayer
   ARCHIVE DESTINATION lib
@@ -130,6 +151,7 @@ ament_export_libraries(
   resize
   debayer
   rectify
+  crop_decimate
 )
 
 ament_package()

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -121,7 +121,7 @@ install(
 )
 install(
   TARGETS crop_decimate
-  EXPORT export_resize
+  EXPORT export_crop_decimate
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -145,6 +145,7 @@ ament_export_interfaces(
   export_resize HAS_LIBRARY_TARGET
   export_debayer HAS_LIBRARY_TARGET
   export_rectify HAS_LIBRARY_TARGET
+  export_crop_decimate HAS_LIBRARY_TARGET
 )
 
 ament_export_libraries(

--- a/image_proc/include/crop_decimate.hpp
+++ b/image_proc/include/crop_decimate.hpp
@@ -1,0 +1,69 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2008, 2019 Willow Garage, Inc., Steve Macenski
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef IMAGE_PROC_CROP_DECIMATE_H
+#define IMAGE_PROC_CROP_DECIMATE_H
+#include <thread>
+#include <memory>
+#include <vector>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+namespace image_proc {
+
+using namespace cv_bridge;  // CvImage, toCvShare
+
+class CropDecimateNode : public rclcpp::Node
+{
+public:
+  CropDecimateNode(const rclcpp::NodeOptions&);
+
+private:
+  image_transport::Subscriber sub_;
+  image_transport::Publisher pub_;
+  int queue_size_;
+  std::string target_frame_id_;
+
+  void imageCb(const sensor_msgs::msg::Image::ConstSharedPtr image_msg /*,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg*/);
+};
+
+}  // namespace image_proc
+
+#endif  // IMAGE_PROC_CROP_DECIMATE_H

--- a/image_proc/include/crop_decimate.hpp
+++ b/image_proc/include/crop_decimate.hpp
@@ -47,6 +47,14 @@
 
 namespace image_proc {
 
+enum CropDecimateModes {
+  CropDecimate_NN = 0,
+  CropDecimate_Linear = 1,
+  CropDecimate_Cubic = 2,
+  CropDecimate_Area = 3,
+  CropDecimate_Lanczos4 = 4
+};
+
 using namespace cv_bridge;  // CvImage, toCvShare
 
 class CropDecimateNode : public rclcpp::Node
@@ -55,13 +63,15 @@ public:
   CropDecimateNode(const rclcpp::NodeOptions&);
 
 private:
-  image_transport::Subscriber sub_;
-  image_transport::Publisher pub_;
+  image_transport::CameraSubscriber sub_;
+  image_transport::CameraPublisher pub_;
   int queue_size_;
   std::string target_frame_id_;
+  int decimation_x_, decimation_y_, offset_x_, offset_y_, width_, height_;
+  int interpolation_;
 
-  void imageCb(const sensor_msgs::msg::Image::ConstSharedPtr image_msg /*,
-    const sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg*/);
+  void imageCb(const sensor_msgs::msg::Image::ConstSharedPtr image_msg,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
 };
 
 }  // namespace image_proc

--- a/image_proc/include/crop_decimate.hpp
+++ b/image_proc/include/crop_decimate.hpp
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef IMAGE_PROC_CROP_DECIMATE_H
-#define IMAGE_PROC_CROP_DECIMATE_H
+#ifndef IMAGE_PROC__CROP_DECIMATE_HPP_
+#define IMAGE_PROC__CROP_DECIMATE_HPP_
 #include <thread>
 #include <memory>
 #include <vector>
@@ -47,7 +47,7 @@
 
 namespace image_proc {
 
-enum CropDecimateModes {
+enum class CropDecimateModes {
   CropDecimate_NN = 0,
   CropDecimate_Linear = 1,
   CropDecimate_Cubic = 2,
@@ -55,12 +55,12 @@ enum CropDecimateModes {
   CropDecimate_Lanczos4 = 4
 };
 
-using namespace cv_bridge;  // CvImage, toCvShare
+using namespace::cv_bridge;  // CvImage, toCvShare
 
 class CropDecimateNode : public rclcpp::Node
 {
 public:
-  CropDecimateNode(const rclcpp::NodeOptions&);
+  explicit CropDecimateNode(const rclcpp::NodeOptions&);
 
 private:
   image_transport::CameraSubscriber sub_;
@@ -68,7 +68,7 @@ private:
   int queue_size_;
   std::string target_frame_id_;
   int decimation_x_, decimation_y_, offset_x_, offset_y_, width_, height_;
-  int interpolation_;
+  CropDecimateModes interpolation_;
 
   void imageCb(const sensor_msgs::msg::Image::ConstSharedPtr image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
@@ -76,4 +76,4 @@ private:
 
 }  // namespace image_proc
 
-#endif  // IMAGE_PROC_CROP_DECIMATE_H
+#endif  // IMAGE_PROC__CROP_DECIMATE_HPP_

--- a/image_proc/include/resize.hpp
+++ b/image_proc/include/resize.hpp
@@ -54,10 +54,8 @@ public:
   ResizeNode(const rclcpp::NodeOptions &);
 protected:
   // ROS communication
-  image_transport::Publisher pub_image_;
-  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pub_info_;
-  image_transport::Subscriber sub_image_;
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr sub_info_;
+  image_transport::CameraPublisher pub_image_;
+  image_transport::CameraSubscriber sub_image_;
 
   std::string image_topic_;
   std::string camera_info_topic_;
@@ -75,9 +73,8 @@ protected:
 
   void connectCb();
 
-  void imageCb(const sensor_msgs::msg::Image::ConstSharedPtr& image_msg);
-  void infoCb(const sensor_msgs::msg::CameraInfo::SharedPtr info_msg);
-
+  void imageCb(sensor_msgs::msg::Image::ConstSharedPtr image_msg,
+    sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
 };
 } // namespace image_proc
 #endif

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -108,7 +108,8 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions& options)
   offset_y_ = this->declare_parameter("offset_y", 0);
 
   // default: CropDecimate_NN
-  interpolation_ = this->declare_parameter("interpolation", 0);
+  int interpolation = this->declare_parameter("interpolation", 0);
+  interpolation_ = static_cast<CropDecimateModes>(interpolation);
 
   pub_ = image_transport::create_camera_publisher(this, "image_raw");
   sub_ = image_transport::create_camera_subscription(this, "image_raw",
@@ -231,7 +232,7 @@ void CropDecimateNode::imageCb(
   {
     cv::Mat decimated;
 
-    if (interpolation_ == image_proc::CropDecimate_NN)
+    if (interpolation_ == image_proc::CropDecimateModes::CropDecimate_NN)
     {
       // Use optimized method instead of OpenCV's more general NN resize
       int pixel_size = output.image.elemSize();
@@ -272,7 +273,7 @@ void CropDecimateNode::imageCb(
     {
       // Linear, cubic, area, ...
       cv::Size size(output.image.cols / decimation_x, output.image.rows / decimation_y);
-      cv::resize(output.image, decimated, size, 0.0, 0.0, interpolation_);
+      cv::resize(output.image, decimated, size, 0.0, 0.0, static_cast<int>(interpolation_));
     }
 
     output.image = decimated;

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -122,6 +122,10 @@ void CropDecimateNode::imageCb(
 {
   /// @todo Check image dimensions match info_msg
 
+  if (pub_.getNumSubscribers() < 1) {
+    return;
+  }
+
   int decimation_x = decimation_x_;
   int decimation_y = decimation_y_;
 

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -1,0 +1,302 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2008, 2019 Willow Garage, Inc., Steve Macenski
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <algorithm>
+#include <thread>
+#include "crop_decimate.hpp"
+
+namespace image_proc {
+
+CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions& options)
+: Node("CropNonZeroNode", options)
+{
+  queue_size_ = this->declare_parameter("queue_size", 5);
+  target_frame_id_ = this->declare_parameter("target_frame_id", std::string());
+
+  pub_ = image_transport::create_publisher(this, "image_raw");
+  sub_ = image_transport::create_subscription(this, "image_raw",
+    std::bind(&CropDecimateNode::imageCb, this, std::placeholders::_1), "raw");
+}
+
+void CropDecimateNode::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr /*image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg*/)
+{
+  // /// @todo Check image dimensions match info_msg
+  // /// @todo Publish tweaks to config_ so they appear in reconfigure_gui
+
+  // Config config;
+  // {
+  //   std::lock_guard<std::recursive_mutex> lock(config_mutex_);
+  //   config = config_;
+  // }
+  // int decimation_x = config.decimation_x;
+  // int decimation_y = config.decimation_y;
+
+  // // Compute the ROI we'll actually use
+  // bool is_bayer = sensor_msgs::image_encodings::isBayer(image_msg->encoding);
+  // if (is_bayer)
+  // {
+  //   // Odd offsets for Bayer images basically change the Bayer pattern, but that's
+  //   // unnecessarily complicated to support
+  //   config.x_offset &= ~0x1;
+  //   config.y_offset &= ~0x1;
+  //   config.width &= ~0x1;
+  //   config.height &= ~0x1;    
+  // }
+
+  // int max_width = image_msg->width - config.x_offset;
+  // if (max_width <= 0)
+  // {
+  //   RCLCPP_WARN(get_logger(),
+  //     "x offset is outside the input image width: "
+  //     "%i, x offset: %i.", image_msg->width, config.x_offset);
+  //   return;
+  // }
+  // int max_height = image_msg->height - config.y_offset;
+  // if (max_height <= 0)
+  // {
+  //   RCLCPP_WARN(get_logger(),
+  //     "y offset is outside the input image height: "
+  //     "%i, y offset: %i", image_msg->height, config.y_offset);
+  //   return;
+  // }
+  // int width = config.width;
+  // int height = config.height;
+  // if (width == 0 || width > max_width)
+  //   width = max_width;
+  // if (height == 0 || height > max_height)
+  //   height = max_height;
+
+  // // On no-op, just pass the messages along
+  // if (decimation_x == 1               &&
+  //     decimation_y == 1               &&
+  //     config.x_offset == 0            &&
+  //     config.y_offset == 0            &&
+  //     width  == (int)image_msg->width &&
+  //     height == (int)image_msg->height)
+  // {
+  //   pub_.publish(image_msg, info_msg);
+  //   return;
+  // }
+
+  // // Get a cv::Mat view of the source data
+  // CvImageConstPtr source = toCvShare(image_msg);
+
+  // // Except in Bayer downsampling case, output has same encoding as the input
+  // CvImage output(source->header, source->encoding);
+  // // Apply ROI (no copy, still a view of the image_msg data)
+  // output.image = source->image(cv::Rect(config.x_offset, config.y_offset, width, height));
+
+  // // Special case: when decimating Bayer images, we first do a 2x2 decimation to BGR
+  // if (is_bayer && (decimation_x > 1 || decimation_y > 1))
+  // {
+  //   if (decimation_x % 2 != 0 || decimation_y % 2 != 0)
+  //   {
+  //     RCLCPP_ERROR(get_logger(),
+  //       "Odd decimation not supported for Bayer images");
+  //     return;
+  //   }
+
+  //   cv::Mat bgr;
+  //   int step = output.image.step1();
+  //   if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_RGGB8)
+  //     debayer2x2toBGR<uint8_t>(output.image, bgr, 0, 1, step, step + 1);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_BGGR8)
+  //     debayer2x2toBGR<uint8_t>(output.image, bgr, step + 1, 1, step, 0);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_GBRG8)
+  //     debayer2x2toBGR<uint8_t>(output.image, bgr, step, 0, step + 1, 1);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_GRBG8)
+  //     debayer2x2toBGR<uint8_t>(output.image, bgr, 1, 0, step + 1, step);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_RGGB16)
+  //     debayer2x2toBGR<uint16_t>(output.image, bgr, 0, 1, step, step + 1);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_BGGR16)
+  //     debayer2x2toBGR<uint16_t>(output.image, bgr, step + 1, 1, step, 0);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_GBRG16)
+  //     debayer2x2toBGR<uint16_t>(output.image, bgr, step, 0, step + 1, 1);
+  //   else if (image_msg->encoding == sensor_msgs::image_encodings::BAYER_GRBG16)
+  //     debayer2x2toBGR<uint16_t>(output.image, bgr, 1, 0, step + 1, step);
+  //   else
+  //   {
+  //     RCLCPP_ERROR(get_logger(), "Unrecognized Bayer encoding '%s'",
+  //       image_msg->encoding.c_str());
+  //     return;
+  //   }
+
+  //   output.image = bgr;
+  //   output.encoding = (bgr.depth() == CV_8U) ? sensor_msgs::image_encodings::BGR8
+  //                                            : sensor_msgs::image_encodings::BGR16;
+  //   decimation_x /= 2;
+  //   decimation_y /= 2;
+  // }
+
+  // // Apply further downsampling, if necessary
+  // if (decimation_x > 1 || decimation_y > 1)
+  // {
+  //   cv::Mat decimated;
+
+  //   if (config.interpolation == image_proc::CropDecimate_NN)
+  //   {
+  //     // Use optimized method instead of OpenCV's more general NN resize
+  //     int pixel_size = output.image.elemSize();
+  //     switch (pixel_size)
+  //     {
+  //       // Currently support up through 4-channel float
+  //       case 1:
+  //         decimate<1>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 2:
+  //         decimate<2>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 3:
+  //         decimate<3>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 4:
+  //         decimate<4>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 6:
+  //         decimate<6>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 8:
+  //         decimate<8>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 12:
+  //         decimate<12>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       case 16:
+  //         decimate<16>(output.image, decimated, decimation_x, decimation_y);
+  //         break;
+  //       default:
+  //         RCLCPP_ERROR(get_logger(),
+  //           "Unsupported pixel size, %d bytes", pixel_size);
+  //         return;
+  //     }
+  //   }
+  //   else
+  //   {
+  //     // Linear, cubic, area, ...
+  //     cv::Size size(output.image.cols / decimation_x, output.image.rows / decimation_y);
+  //     cv::resize(output.image, decimated, size, 0.0, 0.0, config.interpolation);
+  //   }
+
+  //   output.image = decimated;
+  // }
+
+  // // Create output Image message
+  // /// @todo Could save copies by allocating this above and having output.image alias it
+  // sensor_msgs::ImagePtr out_image = output.toImageMsg();
+
+  // // Create updated CameraInfo message
+  // sensor_msgs::CameraInfoPtr out_info = std::make_shared<sensor_msgs::CameraInfo>(*info_msg);
+  // int binning_x = std::max((int)info_msg->binning_x, 1);
+  // int binning_y = std::max((int)info_msg->binning_y, 1);
+  // out_info->binning_x = binning_x * config.decimation_x;
+  // out_info->binning_y = binning_y * config.decimation_y;
+  // out_info->roi.x_offset += config.x_offset * binning_x;
+  // out_info->roi.y_offset += config.y_offset * binning_y;
+  // out_info->roi.height = height * binning_y;
+  // out_info->roi.width = width * binning_x;
+  // // If no ROI specified, leave do_rectify as-is. If ROI specified, set do_rectify = true.
+  // if (width != (int)image_msg->width || height != (int)image_msg->height)
+  //   out_info->roi.do_rectify = true;
+
+  // if (!target_frame_id_.empty()) {
+  //   out_image->header.frame_id = target_frame_id_;
+  //   out_info->header.frame_id = target_frame_id_;
+  // }
+
+  // pub_.publish(out_image, out_info);
+}
+
+template <typename T>
+void debayer2x2toBGR(const cv::Mat& src, cv::Mat& dst, int R, int G1, int G2, int B)
+{
+  typedef cv::Vec<T, 3> DstPixel; // 8- or 16-bit BGR
+  dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
+
+  int src_row_step = src.step1();
+  int dst_row_step = dst.step1();
+  const T* src_row = src.ptr<T>();
+  T* dst_row = dst.ptr<T>();
+
+  // 2x2 downsample and debayer at once
+  for (int y = 0; y < dst.rows; ++y)
+  {
+    for (int x = 0; x < dst.cols; ++x)
+    {
+      dst_row[x*3 + 0] = src_row[x*2 + B];
+      dst_row[x*3 + 1] = (src_row[x*2 + G1] + src_row[x*2 + G2]) / 2;
+      dst_row[x*3 + 2] = src_row[x*2 + R];
+    }
+    src_row += src_row_step * 2;
+    dst_row += dst_row_step;
+  }
+}
+
+// Templated on pixel size, in bytes (MONO8 = 1, BGR8 = 3, RGBA16 = 8, ...)
+template <int N>
+void decimate(const cv::Mat& src, cv::Mat& dst, int decimation_x, int decimation_y)
+{
+  dst.create(src.rows / decimation_y, src.cols / decimation_x, src.type());
+
+  int src_row_step = src.step[0] * decimation_y;
+  int src_pixel_step = N * decimation_x;
+  int dst_row_step = dst.step[0];
+
+  const uint8_t* src_row = src.ptr();
+  uint8_t* dst_row = dst.ptr();
+  
+  for (int y = 0; y < dst.rows; ++y)
+  {
+    const uint8_t* src_pixel = src_row;
+    uint8_t* dst_pixel = dst_row;
+    for (int x = 0; x < dst.cols; ++x)
+    {
+      memcpy(dst_pixel, src_pixel, N); // Should inline with small, fixed N
+      src_pixel += src_pixel_step;
+      dst_pixel += N;
+    }
+    src_row += src_row_step;
+    dst_row += dst_row_step;
+  }
+}
+
+} // namespace image_proc
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(image_proc::CropDecimateNode)

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -103,6 +103,11 @@ void RectifyNode::connectCb( )
 void RectifyNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
                              const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
+  if (pub_rect_.getNumSubscribers() < 1)
+  {
+    return;
+  }
+
   // Verify camera is actually calibrated
   if (info_msg->k[0] == 0.0) {
     RCLCPP_ERROR(this->get_logger(), "Rectified topic '%s' requested but camera publishing '%s' "

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -140,6 +140,11 @@ void ResizeNode::infoCb(const sensor_msgs::msg::CameraInfo::SharedPtr info_msg)
 
 void ResizeNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr& image_msg)
 {
+  if (pub_image_.getNumSubscribers() < 1)
+  {
+    return;
+  }
+
   cv_bridge::CvImagePtr cv_ptr;
   try
   {


### PR DESCRIPTION
@klintan please take a look and note a few things. In particular the use of image transport camera specific publishers and subscribers. They let you get the camera info and message synchronized. This is important for RVIZ as well as future subscribers needing camera info and data together. I updated the resize component for this as well (on top of the sub counter)

@mjcarroll can you take a look? Can't well nit-pick my own PR to death. Edit: Josh came to the rescue. 

Wildly untested, but something's better than nothing. @klintan if you can test this the way you're testing your other stuff I'd appreciate the thumbs up on it working as you expect. Still... no... cameras...