### PR TITLE
Install latest package versions during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           name: Set Up Container
           command: |
             apt update -qq && apt install -y build-essential cmake python3-colcon-common-extensions python3-rosdep
+            apt upgrade -y
             source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
             mkdir -p src/image_pipeline && mv `find -maxdepth 1 -not -name . -not -name src` src/image_pipeline/
             rosdep update


### PR DESCRIPTION
It's possible that the packages shipped with the Docker image are not the latest release version
for the distribution.

For example, https://github.com/ros-perception/image_pipeline/pull/486 is using changes in a newer release of Dashing, but CI is failing because the Docker image is not up-to-date.