### PR TITLE
resize.cpp: fix memory leak

### DIFF
--- a/image_proc/src/nodelets/resize.cpp
+++ b/image_proc/src/nodelets/resize.cpp
@@ -64,6 +64,7 @@ protected:
   typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
   std::shared_ptr<ReconfigureServer> reconfigure_server_;
   Config config_;
+  cv_bridge::CvImage scaled_cv_;
 
   virtual void onInit();
   void connectCb();
@@ -173,10 +174,10 @@ void ResizeNodelet::imageCb(const sensor_msgs::ImageConstPtr& image_msg)
     config = config_;
   }
 
-  cv_bridge::CvImagePtr cv_ptr;
+  cv_bridge::CvImageConstPtr cv_ptr;
   try
   {
-    cv_ptr = cv_bridge::toCvCopy(image_msg);
+    cv_ptr = cv_bridge::toCvShare(image_msg);
   }
   catch (cv_bridge::Exception& e)
   {
@@ -186,17 +187,19 @@ void ResizeNodelet::imageCb(const sensor_msgs::ImageConstPtr& image_msg)
 
   if (config.use_scale)
   {
-    cv::resize(cv_ptr->image, cv_ptr->image, cv::Size(0, 0), config.scale_width, config.scale_height,
+    cv::resize(cv_ptr->image, scaled_cv_.image, cv::Size(0, 0), config.scale_width, config.scale_height,
                config.interpolation);
   }
   else
   {
     int height = config.height == -1 ? image_msg->height : config.height;
     int width = config.width == -1 ? image_msg->width : config.width;
-    cv::resize(cv_ptr->image, cv_ptr->image, cv::Size(width, height), 0, 0, config.interpolation);
+    cv::resize(cv_ptr->image, scaled_cv_.image, cv::Size(width, height), 0, 0, config.interpolation);
   }
 
-  pub_image_.publish(cv_ptr->toImageMsg());
+  scaled_cv_.header = image_msg->header;
+  scaled_cv_.encoding = image_msg->encoding;
+  pub_image_.publish(scaled_cv_.toImageMsg());
 }
 
 }  // namespace image_proc


### PR DESCRIPTION
Instantiating `cv::Mat` without passing custom data storage in callback function causes memory leak on the end of callback function.
This PR fixes the issue by using `toCvShare` method to re-use data storage of `image_msg` for an original image and a class member variable `scaled_cv_` which holds `cv::Mat` as a member for a scaled image instead of implicitly initializing `cv::Mat`.