### PR TITLE
[stereo_image_proc] Use sensor data QoS profile

### DIFF
--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -270,10 +270,11 @@ void DisparityNode::connectCb()
 {
   // TODO(jacobperron): Add unsubscribe logic when we use graph events
   image_transport::TransportHints hints(this, "raw");
-  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport());
-  sub_l_info_.subscribe(this, "left/camera_info");
-  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport());
-  sub_r_info_.subscribe(this, "right/camera_info");
+  const auto image_qos_profile = rclcpp::SensorDataQoS().get_rmw_qos_profile();
+  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_qos_profile);
+  sub_l_info_.subscribe(this, "left/camera_info", image_qos_profile);
+  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_qos_profile);
+  sub_r_info_.subscribe(this, "right/camera_info", image_qos_profile);
 }
 
 void DisparityNode::imageCb(

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -130,9 +130,10 @@ void PointCloudNode::connectCb()
 {
   // TODO(jacobperron): Add unsubscribe logic when we use graph events
   image_transport::TransportHints hints(this, "raw");
-  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport());
-  sub_l_info_.subscribe(this, "left/camera_info");
-  sub_r_info_.subscribe(this, "right/camera_info");
+  const auto image_qos_profile = rclcpp::SensorDataQoS().get_rmw_qos_profile();
+  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_qos_profile);
+  sub_l_info_.subscribe(this, "left/camera_info", image_qos_profile);
+  sub_r_info_.subscribe(this, "right/camera_info", image_qos_profile);
   sub_disparity_.subscribe(this, "disparity");
 }
 


### PR DESCRIPTION
I think using this QoS profile makes sense, considering that these nodes are intended to
subscribe to sensor data. The sensor data QoS profile has reliability set to 'best effort',
which will ensure compatibility with publishers using the same setting as well as 'reliable'.

I was prompted to make this change when I had a QoS compatibility issue trying to use
stereo_image_proc with data coming from Gazebo, which uses the sensor data QoS profile for
it's publishers.

We should consider making the same change for other subscriptions and/or publishers in other nodes provided by image_pipeline.