### PR TITLE
Fix import path on camera_calibrator.py

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -47,7 +47,7 @@ try:
     from queue import Queue
 except ImportError:
     from Queue import Queue
-from calibrator import CAMERA_MODEL
+from camera_calibration.calibrator import CAMERA_MODEL
 
 class BufferQueue(Queue):
     """Slight modification of the standard Queue that discards the oldest item


### PR DESCRIPTION
I found out this error while running the Monocular camera calibration tutorial.