### PR TITLE
image_view: add missing depends to package.xml

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(image_transport REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(stereo_msgs REQUIRED)
 

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -22,6 +22,7 @@
   <depend>image_transport</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>stereo_msgs</depend>


### PR DESCRIPTION
I noticed some packages missing from the `image_view` package.xml file when building a large workspace from source. These packages have [find_package calls in the CMakeLists.txt](https://github.com/ros-perception/image_pipeline/blob/ros2/image_view/CMakeLists.txt#L18-L19), so I assume they should be listed in `<depend>` tags as well.