### PR TITLE
Build image_proc as shared library and export

### DIFF
--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -36,11 +36,15 @@ set(dependencies
   rcutils
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/processor.cpp
 )
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 ament_target_dependencies(${PROJECT_NAME}
   image_geometry
@@ -137,12 +141,18 @@ ament_target_dependencies(image_proc_exe
 set_target_properties(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
 
 install(TARGETS
-  ${PROJECT_NAME} image_proc_exe
+  ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
+install(TARGETS image_proc_exe
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 
 install(
   TARGETS crop_decimate
@@ -191,6 +201,7 @@ install(DIRECTORY launch/
 ament_export_include_directories(include)
 
 ament_export_interfaces(
+  export_${PROJECT_NAME} HAS_LIBRARY_TARGET
   export_crop_decimate HAS_LIBRARY_TARGET
   export_crop_non_zero HAS_LIBRARY_TARGET
   export_debayer HAS_LIBRARY_TARGET
@@ -199,6 +210,7 @@ ament_export_interfaces(
 )
 
 ament_export_libraries(
+  ${PROJECT_NAME}
   crop_decimate
   crop_non_zero
   debayer


### PR DESCRIPTION
This fixes a build issue with stereo_image_proc after a change to ament_target_dependencies
exposed an issue in the CMake code: https://github.com/ament/ament_cmake/pull/235

Specifically, since interfaces are being exported by image_proc, ament_target_dependencies
detects this and does not set image_proc_INCLUDE_DIRS as stereo_image_proc was expecting.