### PR TITLE
Add parameter to use system default QoS for image subscriptions in stereo_image_proc

### DIFF
--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -46,9 +46,8 @@ def generate_launch_description():
                         'the left and right cameras do not produce exactly synced timestamps.'
         ),
         DeclareLaunchArgument(
-            name='image_sub_reliability', default_value='best_effort',
-            description='Reliability QoS for the stereo image subscriptions in the disparity '
-                        "and point cloud nodes. Can be 'best_effort' or 'reliable'."
+            name='use_system_default_qos', default_value='False',
+            description='Use the RMW QoS settings for the publishers and subscriptions.'
         ),
         ComposableNodeContainer(
             package='rclcpp_components', node_executable='component_container',
@@ -59,7 +58,7 @@ def generate_launch_description():
                     node_plugin='stereo_image_proc::DisparityNode',
                     parameters=[{
                         'approximate_sync': LaunchConfiguration('approximate_sync'),
-                        'image_sub_reliability': LaunchConfiguration('image_sub_reliability'),
+                        'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
                     }]
                 ),
                 ComposableNode(
@@ -67,7 +66,7 @@ def generate_launch_description():
                     node_plugin='stereo_image_proc::PointCloudNode',
                     parameters=[{
                         'approximate_sync': LaunchConfiguration('approximate_sync'),
-                        'image_sub_reliability': LaunchConfiguration('image_sub_reliability'),
+                        'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
                     }]
                 ),
             ],

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='use_system_default_qos', default_value='False',
-            description='Use the RMW QoS settings for the publishers and subscriptions.'
+            description='Use the RMW QoS settings for the image and camera info subscriptions.'
         ),
         ComposableNodeContainer(
             package='rclcpp_components', node_executable='component_container',

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -45,6 +45,11 @@ def generate_launch_description():
             description='Whether to use approximate synchronization of topics. Set to true if '
                         'the left and right cameras do not produce exactly synced timestamps.'
         ),
+        DeclareLaunchArgument(
+            name='image_sub_reliability', default_value='best_effort',
+            description='Reliability QoS for the stereo image subscriptions in the disparity '
+                        "and point cloud nodes. Can be 'best_effort' or 'reliable'."
+        ),
         ComposableNodeContainer(
             package='rclcpp_components', node_executable='component_container',
             node_name='stereo_image_proc_container', node_namespace='',
@@ -52,12 +57,18 @@ def generate_launch_description():
                 ComposableNode(
                     package='stereo_image_proc',
                     node_plugin='stereo_image_proc::DisparityNode',
-                    parameters=[{'approximate_sync': LaunchConfiguration('approximate_sync')}]
+                    parameters=[{
+                        'approximate_sync': LaunchConfiguration('approximate_sync'),
+                        'image_sub_reliability': LaunchConfiguration('image_sub_reliability'),
+                    }]
                 ),
                 ComposableNode(
                     package='stereo_image_proc',
                     node_plugin='stereo_image_proc::PointCloudNode',
-                    parameters=[{'approximate_sync': LaunchConfiguration('approximate_sync')}]
+                    parameters=[{
+                        'approximate_sync': LaunchConfiguration('approximate_sync'),
+                        'image_sub_reliability': LaunchConfiguration('image_sub_reliability'),
+                    }]
                 ),
             ],
         ),

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -153,7 +153,7 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
-  bool use_system_default_qos = this->declare_parameter("use_system_default_qos", false);
+  this->declare_parameter("use_system_default_qos", false);
 
   // Synchronize callbacks
   if (approx) {
@@ -259,10 +259,7 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   this->declare_parameters("", double_params);
   this->declare_parameters("", bool_params);
 
-  const auto disparity_pub_qos = use_system_default_qos ?
-    rclcpp::SystemDefaultsQoS() : rclcpp::QoS(1);
-  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>(
-    "disparity", disparity_pub_qos);
+  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -41,7 +41,6 @@
 #include <message_filters/sync_policies/exact_time.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
-#include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <stereo_msgs/msg/disparity_image.hpp>
 
@@ -87,10 +86,6 @@ private:
   using ApproximateSync = message_filters::Synchronizer<ApproximatePolicy>;
   std::shared_ptr<ExactSync> exact_sync_;
   std::shared_ptr<ApproximateSync> approximate_sync_;
-
-  // QoS for image and camera info subscriptions
-  rclcpp::QoS image_sub_qos_;
-
   // Publications
   std::shared_ptr<rclcpp::Publisher<stereo_msgs::msg::DisparityImage>> pub_disparity_;
 
@@ -151,36 +146,14 @@ static void add_param_to_map(
 }
 
 DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
-: rclcpp::Node("disparity_node", options),
-  image_sub_qos_(rclcpp::SensorDataQoS())
+: rclcpp::Node("disparity_node", options)
 {
   using namespace std::placeholders;
 
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
-  rcl_interfaces::msg::ParameterDescriptor image_sub_reliability_description;
-  image_sub_reliability_description.description =
-    "Reliability QoS for the image and camera info subscriptions. "
-    "Must be 'best_effort' or 'reliable'.";
-  image_sub_reliability_description.read_only = true;
-  std::string reliability = this->declare_parameter(
-    "image_sub_reliability",
-    "best_effort",
-    image_sub_reliability_description
-  );
-
-  // Validate reliability parameter and initialize QoS profile
-  if ("best_effort" == reliability) {
-    this->image_sub_qos_.best_effort();
-  } else if ("reliable" == reliability) {
-    this->image_sub_qos_.reliable();
-  } else {
-    throw std::runtime_error(
-            "Invalid value for parameter 'image_sub_reliability'. "
-            "Got '" + reliability + "', but must be 'best_effort' or 'reliable'."
-    );
-  }
+  bool use_system_default_qos = this->declare_parameter("use_system_default_qos", false);
 
   // Synchronize callbacks
   if (approx) {
@@ -286,7 +259,10 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   this->declare_parameters("", double_params);
   this->declare_parameters("", bool_params);
 
-  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1);
+  const auto disparity_pub_qos = use_system_default_qos ?
+    rclcpp::SystemDefaultsQoS() : rclcpp::QoS(1);
+  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>(
+    "disparity", disparity_pub_qos);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.
@@ -298,7 +274,12 @@ void DisparityNode::connectCb()
 {
   // TODO(jacobperron): Add unsubscribe logic when we use graph events
   image_transport::TransportHints hints(this, "raw");
-  const auto image_sub_rmw_qos = this->image_sub_qos_.get_rmw_qos_profile();
+  const bool use_system_default_qos = this->get_parameter("use_system_default_qos").as_bool();
+  rclcpp::QoS image_sub_qos = rclcpp::SensorDataQoS();
+  if (use_system_default_qos) {
+    image_sub_qos = rclcpp::SystemDefaultsQoS();
+  }
+  const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
   sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
   sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos);

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -38,6 +38,7 @@
 #include <message_filters/sync_policies/exact_time.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <rcutils/logging_macros.h>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -76,6 +77,9 @@ private:
   std::shared_ptr<ExactSync> exact_sync_;
   std::shared_ptr<ApproximateSync> approximate_sync_;
 
+  // QoS for image and camera info subscriptions
+  rclcpp::QoS image_sub_qos_;
+
   // Publications
   std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> pub_points2_;
 
@@ -93,13 +97,36 @@ private:
 };
 
 PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
-: rclcpp::Node("point_cloud_node", options)
+: rclcpp::Node("point_cloud_node", options),
+  image_sub_qos_(rclcpp::SensorDataQoS())
 {
   using namespace std::placeholders;
 
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
+  rcl_interfaces::msg::ParameterDescriptor image_sub_reliability_description;
+  image_sub_reliability_description.description =
+    "Reliability QoS for the image and camera info subscriptions. "
+    "Must be 'best_effort' or 'reliable'.";
+  image_sub_reliability_description.read_only = true;
+  std::string reliability = this->declare_parameter(
+    "image_sub_reliability",
+    "best_effort",
+    image_sub_reliability_description
+  );
+
+  // Validate reliability parameter and initialize QoS profile
+  if ("best_effort" == reliability) {
+    this->image_sub_qos_.best_effort();
+  } else if ("reliable" == reliability) {
+    this->image_sub_qos_.reliable();
+  } else {
+    throw std::runtime_error(
+            "Invalid value for parameter 'image_sub_reliability'. "
+            "Got '" + reliability + "', but must be 'best_effort' or 'reliable'."
+    );
+  }
 
   // Synchronize callbacks
   if (approx) {
@@ -130,10 +157,10 @@ void PointCloudNode::connectCb()
 {
   // TODO(jacobperron): Add unsubscribe logic when we use graph events
   image_transport::TransportHints hints(this, "raw");
-  const auto image_qos_profile = rclcpp::SensorDataQoS().get_rmw_qos_profile();
-  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_qos_profile);
-  sub_l_info_.subscribe(this, "left/camera_info", image_qos_profile);
-  sub_r_info_.subscribe(this, "right/camera_info", image_qos_profile);
+  const auto image_sub_rmw_qos = this->image_sub_qos_.get_rmw_qos_profile();
+  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos);
+  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
+  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
   sub_disparity_.subscribe(this, "disparity");
 }
 

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -100,7 +100,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
-  bool use_system_default_qos = this->declare_parameter("use_system_default_qos", false);
+  this->declare_parameter("use_system_default_qos", false);
 
   // Synchronize callbacks
   if (approx) {
@@ -119,8 +119,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
       std::bind(&PointCloudNode::imageCb, this, _1, _2, _3, _4));
   }
 
-  const auto pub_qos = use_system_default_qos ? rclcpp::SystemDefaultsQoS() : rclcpp::QoS(1);
-  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", pub_qos);
+  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.
@@ -141,10 +140,7 @@ void PointCloudNode::connectCb()
   sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
   sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
-
-  const auto disparity_sub_qos = use_system_default_qos ?
-    rclcpp::SystemDefaultsQoS() : rclcpp::QoS(1);
-  sub_disparity_.subscribe(this, "disparity", disparity_sub_qos.get_rmw_qos_profile());
+  sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos);
 }
 
 inline bool isValidPoint(const cv::Vec3f & pt)


### PR DESCRIPTION
In some applications, it is desired to have a "reliable" stereo pipeline where we ensure that stereo image messages are always received (ie. no dropped messages). This change gives the user that option.

We are still defaulting to *best effort* reliability for subscriptions because it is the least restrictive when it comes to publisher/subscription QoS compatibility.