### PR TITLE
Add parameter to avoid points2 padding

### DIFF
--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -106,7 +106,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   // can improve performance in some cases or not.
   descriptor.description =
     "This parameter avoids using alignment padding in the generated point cloud."
-    "That allows reducing bandwidth requirements, as the point cloud size is halved."
+    "This reduces bandwidth requirements, as the point cloud size is halved."
     "Using point clouds without alignment padding might degrade performance for some algorithms.";
   this->declare_parameter("avoid_point_cloud_padding", false);
 

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -108,7 +108,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
     "This parameter avoids using alignment padding in the generated point cloud."
     "This reduces bandwidth requirements, as the point cloud size is halved."
     "Using point clouds without alignment padding might degrade performance for some algorithms.";
-  this->declare_parameter("avoid_point_cloud_padding", false);
+  this->declare_parameter("avoid_point_cloud_padding", false, descriptor);
 
   // Synchronize callbacks
   if (approx) {

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -106,7 +106,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   // can improve performance in some cases or not.
   descriptor.description =
     "This parameter avoids using alignment padding in the generated point cloud."
-    "That allows reducing bandwidth requirements."
+    "That allows reducing bandwidth requirements, as the point cloud size is halved."
     "Using point clouds without alignment padding might degrade performance for some algorithms.";
   this->declare_parameter("avoid_point_cloud_padding", false);
 

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -101,6 +101,13 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
   this->declare_parameter("use_system_default_qos", false);
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  // TODO(ivanpauno): Confirm if using point cloud padding in `sensor_msgs::msg::PointCloud2`
+  // can improve performance in some cases or not.
+  descriptor.description =
+    "This parameter avoids using alignment padding in the generated point cloud."
+    "That allows reducing bandwidth requirements."
+    "Using point clouds without alignment padding might degrade performance for some algorithms.";
   this->declare_parameter("avoid_point_cloud_padding", false);
 
   // Synchronize callbacks


### PR DESCRIPTION
This PR adds a parameter to `stereo_image_proc` `point_cloud_node`, which allows to send a point cloud without the standard PCL padding.

The motivation of this is that the out of the box performance of all the available `rmw` implementations with large data is really bad, even when using the `loopback` interface (any rmw imp) or shared memory transport (in `Connext`).

e.g.: To send a point cloud generated from a 640x480 image, the resulting size (with padding) is 640x480x32B = 9830400B = 9.4MB, and messages are lost even when the publisher and subscription are reliable.

It's possible to make it work with some tweaking of the receiver buffer size (increased to 8MB) when only using UDPv4 transport (tried with `cyclonedds` and `connext`). This requires to also tweak kernel `rmem_max`.
When using shared memory (only tried with `connext`), the receiver buffer size has to also be tweaked (to 16MB) to make the communication work.

When not using padding, the image is half the size, and the buffers sizes to make the communication work can also be halved.

Besides the current problems in the different DDS vendors we're using, I imagine that for many scenarios where bandwidth is limited, reducing the pointcloud size to the half might be a good option, even if it's needed to repack the point-cloud with padding before processing.

P.S.: The padding is required by `PCL`, to be able to use `SIMD`/etc.