### PR TITLE
clone cv_ptr->image before set queued_image

### DIFF
--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -227,7 +227,7 @@ void ImageNodelet::imageCb(const sensor_msgs::ImageConstPtr& msg)
       options.max_image_value = max_image_value_;
     }
     cv_ptr = cvtColorForDisplay(cv_bridge::toCvShare(msg), "", options);
-    queued_image_.set(cv_ptr->image);
+    queued_image_.set(cv_ptr->image.clone());
   }
   catch (cv_bridge::Exception& e) {
     NODELET_ERROR_THROTTLE(30, "Unable to convert '%s' image for display: '%s'",


### PR DESCRIPTION
This fixes https://github.com/ros-perception/image_pipeline/issues/498#issuecomment-585856089, image_view segfaults on version 1.14.0 of 18.04 , and it works on 1.13.0.

The is because that https://github.com/ros-perception/image_pipeline/pull/479 convert image_view node to use nodelet codes, which changes image_view processing. 
And gdb output is as follows. I am not quite sure what is the exact reason, but at least. This PR fixes on my environment.

```
Thread 23 "image_view" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffa4411700 (LWP 15650)]
0x00007fffdc04c220 in cvConvertImage ()
   from /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.so.3.2
(gdb) where
    at /usr/lib/x86_64-linux-gnu/libopencv_imgcodecs.so.3.2
    at /usr/lib/x86_64-linux-gnu/libopencv_highgui.so.3.2
    at /usr/lib/x86_64-linux-gnu/libopencv_highgui.so.3.2
    at /home/k-okada/catkin_ws/ws_recognition/devel/lib//libimage_view.so
    at /home/k-okada/catkin_ws/ws_recognition/devel/lib//libimage_view.so
    at /home/k-okada/catkin_ws/ws_recognition/devel/lib//libimage_view.so
```

you can check with launch file follows:
```
<launch>
  <node pkg="image_publisher" type="image_publisher"
        name="image_publisher"
        args="$(find rviz)/images/splash.png" />

  <!-- node -->
  <node pkg="image_view" type="image_view"
        name="image_view" >
    <remap from="image" to="/image_publisher/image_raw" />
  </node>

  <!-- nodelet -->
  <node pkg="nodelet" type="nodelet"
        name="nodelet_image_view"
        args="standalone image_view/image" >
    <remap from="image" to="/image_publisher/image_raw" />
  </node>
```