### PR TITLE
image_view: add missing dependency to gencfg header

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(image_view ${catkin_LIBRARIES}
                                  ${OpenCV_LIBRARIES}
                                  ${Boost_LIBRARIES}
 )
+add_dependencies(image_view ${PROJECT_NAME}_gencfg)
 install(TARGETS image_view
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
image_view (library) build may fail because of the missing
dependency to image_view_gencfg.

failed build log:
```
[  5%] Building CXX object CMakeFiles/disparity_view.dir/src/nodes/disparity_view.cpp.o
[ 11%] Building CXX object CMakeFiles/image_view.dir/src/nodelets/image_nodelet.cpp.o
/home/builder/aports/ros/noetic/image_view/abuild/src/image_view/src/nodelets/image_nodelet.cpp:34:10: fatal error: image_view/ImageViewConfig.h: No such file or directory
   34 | #include <image_view/ImageViewConfig.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
ref: https://github.com/seqsense/aports-ros-experimental/pull/238