### PR TITLE
image_view: add missing dependency to gencfg header

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(image_view ${catkin_LIBRARIES}
                                  ${OpenCV_LIBRARIES}
                                  ${Boost_LIBRARIES}
 )
+add_dependencies(image_view ${PROJECT_NAME}_gencfg)
 install(TARGETS image_view
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
image_view (library) build may fail because of the missing
dependency to image_view_gencfg.

(backport of https://github.com/ros-perception/image_pipeline/pull/531)