### PR TITLE
Use OpenCV 3.2 on Buster

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -3,10 +3,13 @@ project(image_publisher)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure camera_info_manager sensor_msgs image_transport nodelet roscpp)
 
-set(opencv_4_components core imgcodecs videoio)
 find_package(OpenCV REQUIRED COMPONENTS core)
 message(STATUS "opencv version ${OpenCV_VERSION}")
-find_package(OpenCV 4 REQUIRED COMPONENTS ${opencv_4_components})
+if(OpenCV_VERSION VERSION_LESS "4.0.0")
+  find_package(OpenCV 3 REQUIRED COMPONENTS core imgcodecs videoio)
+else()
+  find_package(OpenCV 4 REQUIRED COMPONENTS core imgcodecs videoio)
+endif()
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(cfg/ImagePublisher.cfg)


### PR DESCRIPTION
This should fix the binary job for `image_publisher` on Debian Buster. It uses OpenCV 3 if OpenCV 4 is not available.

http://build.ros.org/view/Nbin_db_dB64/job/Nbin_db_dB64__image_publisher__debian_buster_amd64__binary/4/

@SteveMacenski @JWhitleyWork assuming the change looks ok to you, would you be willing to make a new Noetic release with it today?