### PR TITLE
[melodic][image_publisher] adapt to OpenCV4

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -3,15 +3,7 @@ project(image_publisher)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure camera_info_manager sensor_msgs image_transport nodelet roscpp)
 
-set(opencv_2_components core highgui)
-set(opencv_3_components core imgcodecs videoio)
-find_package(OpenCV REQUIRED COMPONENTS core)
-message(STATUS "opencv version ${OpenCV_VERSION}")
-if(OpenCV_VERSION VERSION_LESS "3.0.0")
-  find_package(OpenCV 2 REQUIRED COMPONENTS ${opencv_2_components})  
-else()
-  find_package(OpenCV 3 REQUIRED COMPONENTS ${opencv_3_components})  
-endif()
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs videoio)
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(cfg/ImagePublisher.cfg)

--- a/image_publisher/src/nodelet/image_publisher_nodelet.cpp
+++ b/image_publisher/src/nodelet/image_publisher_nodelet.cpp
@@ -95,7 +95,7 @@ class ImagePublisherNodelet : public nodelet::Nodelet
     {
       if ( cap_.isOpened() ) {
         if ( ! cap_.read(image_) ) {
-          cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
+          cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
         }
       }
       if (flip_image_)
@@ -136,7 +136,7 @@ public:
     nh_.param("filename", filename_, std::string(""));
     NODELET_INFO("File name for publishing image is : %s", filename_.c_str());
     try {
-      image_ = cv::imread(filename_, CV_LOAD_IMAGE_COLOR);
+      image_ = cv::imread(filename_, cv::IMREAD_COLOR);
       if ( image_.empty() ) { // if filename is motion file or device file
         try {  // if filename is number
           int num = boost::lexical_cast<int>(filename_);//num is 1234798797
@@ -146,7 +146,7 @@ public:
         }
         CV_Assert(cap_.isOpened());
         cap_.read(image_);
-        cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
+        cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
       }
       CV_Assert(!image_.empty());
     }


### PR DESCRIPTION
This pull request adapts the image publisher to OpenCV4 while keeping OpenCV3 compatibility. Backwards compatibility to OpenCV2 has been removed because ROS Melodic targets OpenCV3.2+ (see [REP 3](https://www.ros.org/reps/rep-0003.html#melodic-morenia-may-2018-may-2023)).