### PR TITLE
[image_view] allow filename_format without format specifier

### DIFF
--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -260,7 +260,15 @@ void ImageNodelet::mouseCb(int event, int x, int y, int flags, void* param)
     return;
   }
 
-  std::string filename = (this_->filename_format_ % this_->count_).str();
+  std::string filename;
+  try
+  {
+    filename = (this_->filename_format_ % this_->count_).str();
+  }
+  catch (const boost::io::too_many_args&)
+  {
+    filename = (this_->filename_format_).str();
+  }
   if (cv::imwrite(filename, image))
   {
     NODELET_INFO("Saved image %s", filename.c_str());


### PR DESCRIPTION
In this pull request, I allow `filename_format` rosparam without format specifier.

For example, the default value of `filename_format` is "frame%04i.jpg"
With this pull request, "frame.jpg" is allowed.