### PR TITLE
fixes for fisheye calibration

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -314,7 +314,6 @@ class Calibrator(object):
 
     def set_cammodel(self, modeltype):
         self.camera_model = modeltype
-        #print("cam model set: " + str(self.camera_model))
 
     def is_slow_moving(self, corners, last_frame_corners):
         """
@@ -854,7 +853,7 @@ class MonoCalibrator(Calibrator):
                     self.db.append((params, gray))
                     self.good_corners.append((corners, board))
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
-        
+
         self.last_frame_corners = corners
         rv = MonoDrawable()
         rv.scrib = scrib
@@ -1053,12 +1052,12 @@ class StereoCalibrator(Calibrator):
 
         elif self.camera_model == CAMERA_MODEL.FISHEYE:
             self.Q = numpy.zeros((4,4), dtype=numpy.float64)
-            
+
             flags = cv2.CALIB_ZERO_DISPARITY   # Operation flags that may be zero or CALIB_ZERO_DISPARITY .
                             # If the flag is set, the function makes the principal points of each camera have the same pixel coordinates in the rectified views.
-                            # And if the flag is not set, the function may still shift the images in the horizontal or vertical direction 
+                            # And if the flag is not set, the function may still shift the images in the horizontal or vertical direction
                             # (depending on the orientation of epipolar lines) to maximize the useful image area.
-            
+
             cv2.fisheye.stereoRectify(self.l.intrinsics, self.l.distortion,
                              self.r.intrinsics, self.r.distortion,
                              self.size,
@@ -1233,7 +1232,7 @@ class StereoCalibrator(Calibrator):
                     self.db.append( (params, lgray, rgray) )
                     self.good_corners.append( (lcorners, rcorners, lboard) )
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
-        
+
         self.last_frame_corners = lcorners
         rv = StereoDrawable()
         rv.lscrib = lscrib
@@ -1286,7 +1285,7 @@ class StereoCalibrator(Calibrator):
 
         if not len(limages) == len(rimages):
             raise CalibrationException("Left, right images don't match. %d left images, %d right" % (len(limages), len(rimages)))
-        
+
         ##\todo Check that the filenames match and stuff
 
         self.cal(limages, rimages)

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -83,7 +83,7 @@ class DisplayThread(threading.Thread):
         cv2.setMouseCallback("display", self.opencv_calibration_node.on_mouse)
         cv2.createTrackbar("Camera type: \n 0 : pinhole \n 1 : fisheye", "display", 0,1, self.opencv_calibration_node.on_model_change)
         cv2.createTrackbar("scale", "display", 0, 100, self.opencv_calibration_node.on_scale)
-        
+
         while True:
             if self.queue.qsize() > 0:
                 self.image = self.queue.get()
@@ -152,7 +152,7 @@ class CalibrationNode:
         self.q_stereo = BufferQueue(queue_size)
 
         self.c = None
-        
+
         self._last_display = None
 
         mth = ConsumerThread(self.q_mono, self.handle_monocular)


### PR DESCRIPTION
fix #503:
set_cammodel of StereoCalibrator need to override the method of parent class

fix related to https://github.com/opencv/opencv/issues/11085

unlike cv2.calibrate, the cv2.fisheye.calibrate method expects float64 points and in an array with an extra dimension. The same for cv2.stereoCalibrate vs cv2.fisheye.stereoCalibrate