### PR TITLE
Add ChArUco board target

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -53,7 +53,7 @@ def main():
                         "You must specify one or more chessboards as pairs of --size and --square options.")
     group.add_option("-p", "--pattern",
                      type="string", default="chessboard",
-                     help="calibration pattern to detect - 'chessboard', 'circles', 'acircles'")
+                     help="calibration pattern to detect - 'chessboard', 'circles', 'acircles', 'charuco'")
     group.add_option("-s", "--size",
                      action="append", default=[],
                      help="chessboard size as NxM, counting interior corners (e.g. a standard chessboard is 7x7)")
@@ -98,7 +98,7 @@ def main():
     group.add_option("--fisheye-k-coefficients",
                      type="int", default=4, metavar="NUM_COEFFS",
                      help="for fisheye, number of radial distortion coefficients to use fixing to zero the rest (up to 4, default %default)")
-    
+
     group.add_option("--fisheye-check-conditions",
                      action="store_true", default=False,
                      help="for fisheye, the functions will check validity of condition number")
@@ -180,6 +180,8 @@ def main():
         pattern = Patterns.Circles
     elif options.pattern == 'acircles':
         pattern = Patterns.ACircles
+    elif options.pattern == 'charuco':
+        pattern = Patterns.ChArUco
     elif options.pattern != 'chessboard':
         print('Unrecognized pattern %s, defaulting to chessboard' % options.pattern)
 

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -135,11 +135,11 @@ def main():
     if options.pattern == "charuco":
         for (sz, sq, ms, ad) in zip(options.size, options.square, options.marker_size, options.aruco_dict):
             size = tuple([int(c) for c in sz.split('x')])
-            boards.append(ChessboardInfo(size[0], size[1], float(sq), float(ms), ad))
+            boards.append(ChessboardInfo('charuco', size[0], size[1], float(sq), float(ms), ad))
     else:
         for (sz, sq) in zip(options.size, options.square):
             size = tuple([int(c) for c in sz.split('x')])
-            boards.append(ChessboardInfo(size[0], size[1], float(sq)))
+            boards.append(ChessboardInfo(options.pattern, size[0], size[1], float(sq)))
 
     if options.approximate == 0.0:
         sync = message_filters.TimeSynchronizer

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -53,13 +53,22 @@ def main():
                         "You must specify one or more chessboards as pairs of --size and --square options.")
     group.add_option("-p", "--pattern",
                      type="string", default="chessboard",
-                     help="calibration pattern to detect - 'chessboard', 'circles', 'acircles', 'charuco'")
+                     help="calibration pattern to detect - 'chessboard', 'circles', 'acircles', 'charuco'\n" +
+                     "  if 'charuco' is used, a --marker_size and --aruco_dict argument must be supplied\n" +
+                     "  with each --size and --square argument")
     group.add_option("-s", "--size",
                      action="append", default=[],
                      help="chessboard size as NxM, counting interior corners (e.g. a standard chessboard is 7x7)")
     group.add_option("-q", "--square",
                      action="append", default=[],
                      help="chessboard square size in meters")
+    group.add_option("-m", "--marker_size",
+                     action="append", default=[],
+                     help="ArUco marker size (meters); only valid with `-p charuco`")
+    group.add_option("-d", "--aruco_dict",
+                     action="append", default=[],
+                     help="ArUco marker dictionary; only valid with `-p charuco`; one of 'aruco_orig', '4x4_250', " +
+                     "'5x5_250', '6x6_250', '7x7_250'")
     parser.add_option_group(group)
     group = OptionGroup(parser, "ROS Communication Options")
     group.add_option("--approximate",
@@ -113,7 +122,9 @@ def main():
 
     options, args = parser.parse_args()
 
-    if len(options.size) != len(options.square):
+    if (len(options.size) != len(options.square)) or (options.pattern == "charuco" and (
+        (len(options.size) != len(options.marker_size)) or
+        (len(options.size) != len(options.aruco_dict)))):
         parser.error("Number of size and square inputs must be the same!")
 
     if not options.square:
@@ -121,9 +132,14 @@ def main():
         options.size.append("8x6")
 
     boards = []
-    for (sz, sq) in zip(options.size, options.square):
-        size = tuple([int(c) for c in sz.split('x')])
-        boards.append(ChessboardInfo(size[0], size[1], float(sq)))
+    if options.pattern == "charuco":
+        for (sz, sq, ms, ad) in zip(options.size, options.square, options.marker_size, options.aruco_dict):
+            size = tuple([int(c) for c in sz.split('x')])
+            boards.append(ChessboardInfo(size[0], size[1], float(sq), float(ms), ad))
+    else:
+        for (sz, sq) in zip(options.size, options.square):
+            size = tuple([int(c) for c in sz.split('x')])
+            boards.append(ChessboardInfo(size[0], size[1], float(sq)))
 
     if options.approximate == 0.0:
         sync = message_filters.TimeSynchronizer

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -59,7 +59,7 @@ class CAMERA_MODEL(Enum):
 
 # Supported calibration patterns
 class Patterns:
-    Chessboard, Circles, ACircles = list(range(3))
+    Chessboard, Circles, ACircles, ChaRuCo = list(range(4))
 
 class CalibrationException(Exception):
     pass
@@ -95,7 +95,7 @@ def _get_outside_corners(corners, board):
 
     if corners.shape[1] * corners.shape[0] != xdim * ydim:
         raise Exception("Invalid number of corners! %d corners. X: %d, Y: %d" % (corners.shape[1] * corners.shape[0],
-                                                                                 xdim, ydim))
+                                                                                xdim, ydim))
 
     up_left    = corners[0,0]
     up_right   = corners[xdim - 1,0]
@@ -240,7 +240,7 @@ class Calibrator(object):
     def __init__(self, boards, flags=0, fisheye_flags = 0, pattern=Patterns.Chessboard, name='',
     checkerboard_flags=cv2.CALIB_CB_FAST_CHECK, max_chessboard_speed = -1.0):
         # Ordering the dimensions for the different detectors is actually a minefield...
-        if pattern == Patterns.Chessboard:
+        if pattern == Patterns.Chessboard or pattern == Patterns.ChArUco:
             # Make sure n_cols > n_rows to agree with OpenCV CB detector output
             self._boards = [ChessboardInfo(max(i.n_cols, i.n_rows), min(i.n_cols, i.n_rows), i.dim) for i in boards]
         elif pattern == Patterns.ACircles:
@@ -407,6 +407,9 @@ class Calibrator(object):
         for b in self._boards:
             if self.pattern == Patterns.Chessboard:
                 (ok, corners) = _get_corners(img, b, refine, self.checkerboard_flags)
+            elif self.pattern = Patterns.ChArUco:
+                # TODO: ChArUco
+                ok = False
             else:
                 (ok, corners) = _get_circles(img, b, self.pattern)
             if ok:


### PR DESCRIPTION
This PR adds the option of using a ChArUco board for calibration, as requested in #191. It proved more complicated than I expected, based on how the application is structured.

A ChArUco calibration can be performed with the image below as follows:
`rosrun camera_calibration cameracalibrator.py --pattern charuco --size 5x7 --marker_size 0.0172 --square 0.0279 --aruco_dict 5x5_250`
![charuco 5x7](https://user-images.githubusercontent.com/519268/84823785-26646100-afdc-11ea-87c4-e58b26796e8f.png)
