### PR TITLE
Removed basestring (no longer exists in new python 3 version).

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -32,10 +32,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 from io import BytesIO
 import cv2
 import cv_bridge
@@ -882,8 +878,8 @@ class MonoCalibrator(Calibrator):
         """ Write images and calibration solution to a tarfile object """
 
         def taradd(name, buf):
-            if isinstance(buf, basestring):
-                s = StringIO(buf)
+            if isinstance(buf, str):
+                s = BytesIO(buf.encode('utf-8'))
             else:
                 s = BytesIO(buf)
             ti = tarfile.TarInfo(name)
@@ -1263,8 +1259,8 @@ class StereoCalibrator(Calibrator):
                [("right-%04d.png" % i, im) for i,(_, _, im) in enumerate(self.db)])
 
         def taradd(name, buf):
-            if isinstance(buf, basestring):
-                s = StringIO(buf)
+            if isinstance(buf, str):
+                s = BytesIO(buf.encode('utf-8'))
             else:
                 s = BytesIO(buf)
             ti = tarfile.TarInfo(name)


### PR DESCRIPTION
Fixes #551

Note: Only tested on Ubuntu 20.04, python 3.8.2.