### PR TITLE
Removed basestring (no longer exists in new python 3 version).

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -32,10 +32,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 from io import BytesIO
 import cv2
 import cv_bridge
@@ -1122,7 +1118,7 @@ class StereoCalibrator(Calibrator):
 
         def taradd(name, buf):
             if isinstance(buf, str):
-                s = StringIO(buf)
+                s = BytesIO(buf.encode('utf-8'))
             else:
                 s = BytesIO(buf)
             ti = tarfile.TarInfo(name)


### PR DESCRIPTION
Fixes #551