### PR TITLE
Fix image_publisher installation

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -59,9 +59,6 @@ install(TARGETS image_publisher_node
 install(TARGETS image_publisher
         DESTINATION lib/${PROJECT_NAME}
 )
-install(TARGETS image_publisher
-        DESTINATION bin
-)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}/
 )


### PR DESCRIPTION
The `libimage_publisher.so` library currently gets wrongly installed into `install/image_publisher/bin` when compiling from source, and into `/opt/ros/foxy/bin` when installing with Apt. This PR updates the CMake install commands for it to be as they would be when generated by `ros2 pkg create`, so that the library gets installed correctly at `install/image_publisher/lib/libimage_publisher.so`.