### PR TITLE
updated linear_error function to handle partial board views

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1374,7 +1374,7 @@ class StereoCalibrator(Calibrator):
                 params = self.get_parameters(lcorners, lids, lboard, (lgray.shape[1], lgray.shape[0]))
                 if self.is_good_sample(params, lcorners, lids, self.last_frame_corners, self.last_frame_ids):
                     self.db.append( (params, lgray, rgray) )
-                    self.good_corners.append( (lcorners, rcorners, lboard) )
+                    self.good_corners.append( (lcorners, rcorners, lids, rids, lboard) )
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
 
         self.last_frame_corners = lcorners

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -911,7 +911,7 @@ class MonoCalibrator(Calibrator):
         for row in range(n_rows):
             row_min = row * n_cols
             row_max = (row+1) * n_cols
-            pts_in_row = filter(lambda x: row_min <= x < row_max, ids)
+            pts_in_row = [x for x in ids if row_min <= x < row_max]
 
             # not enough points to calculate error
             if len(pts_in_row) <= 2: continue

--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -145,7 +145,7 @@ class CameraCheckerNode:
         return self.mc.mkgray(msg)
 
     def image_corners(self, im):
-        (ok, corners, b) = self.mc.get_corners(im)
+        (ok, corners, ids, b) = self.mc.get_corners(im)
         if ok:
             return corners, ids
         else:

--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -147,7 +147,7 @@ class CameraCheckerNode:
     def image_corners(self, im):
         (ok, corners, b) = self.mc.get_corners(im)
         if ok:
-            return corners
+            return corners, ids
         else:
             return None
 
@@ -155,9 +155,9 @@ class CameraCheckerNode:
 
         (image, camera) = msg
         gray = self.mkgray(image)
-        C = self.image_corners(gray)
+        C, ids = self.image_corners(gray)
         if C is not None:
-            linearity_rms = self.mc.linear_error(C, self.board)
+            linearity_rms = self.mc.linear_error(C, ids, self.board)
 
             # Add in reprojection check
             image_points = C
@@ -188,8 +188,8 @@ class CameraCheckerNode:
         lgray = self.mkgray(lmsg)
         rgray = self.mkgray(rmsg)
 
-        L = self.image_corners(lgray)
-        R = self.image_corners(rgray)
+        L, _ = self.image_corners(lgray)
+        R, _ = self.image_corners(rgray)
         if L is not None and R is not None:
             epipolar = self.sc.epipolar_error(L, R)
 


### PR DESCRIPTION
Modified `linear_error` to work with partial board views, which are now possible with a ChArUco target.