### PR TITLE
Opencv 3 compatibility

### DIFF
--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -18,7 +18,10 @@ find_package(rcutils REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(OpenCV 4 REQUIRED)
+find_package(OpenCV REQUIRED)
+if(OpenCV_VERSION VERSION_LESS "3.2.0")
+  message(FATAL "Minimum OpenCV version is 3.2.0 (found version ${OpenCV_VERSION})")
+endif()
 find_package(image_geometry REQUIRED)
 
 include_directories(

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -46,7 +46,13 @@ void debayer2x2toBGR(
   int R, int G1, int G2, int B)
 {
   typedef cv::Vec<T, 3> DstPixel;  // 8- or 16-bit BGR
-  dst.create(src.rows / 2, src.cols / 2, cv::traits::Type<DstPixel>::value);
+#if CV_VERSION_MAJOR >= 3 && CV_VERSION_MINOR >= 2
+  // Use OpenCV 3 API
+  dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
+#else
+  // Assume OpenCV 4
+  dst.create(src.rows / 2, src.cols / 2, cv::traits::DataType<DstPixel>::type);
+#endif
 
   int src_row_step = src.step1();
   int dst_row_step = dst.step1();

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -46,12 +46,11 @@ void debayer2x2toBGR(
   int R, int G1, int G2, int B)
 {
   typedef cv::Vec<T, 3> DstPixel;  // 8- or 16-bit BGR
-#if CV_VERSION_MAJOR >= 3 && CV_VERSION_MINOR >= 2
-  // Use OpenCV 3 API
-  dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
-#else
-  // Assume OpenCV 4
+#if CV_VERSION_MAJOR >= 4
   dst.create(src.rows / 2, src.cols / 2, cv::traits::DataType<DstPixel>::type);
+#else
+  // Assume OpenCV 3 API
+  dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
 #endif
 
   int src_row_step = src.step1();

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -47,7 +47,7 @@ void debayer2x2toBGR(
 {
   typedef cv::Vec<T, 3> DstPixel;  // 8- or 16-bit BGR
 #if CV_VERSION_MAJOR >= 4
-  dst.create(src.rows / 2, src.cols / 2, cv::traits::DataType<DstPixel>::type);
+  dst.create(src.rows / 2, src.cols / 2, cv::traits::Type<DstPixel>::value);
 #else
   // Assume OpenCV 3 API
   dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);

--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -29,9 +29,8 @@ set( DEPENDENCIES
   cv_bridge
 )
 
-find_package(OpenCV REQUIRED COMPONENTS core)
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs videoio)
 message(STATUS "opencv version ${OpenCV_VERSION}")
-find_package(OpenCV 4 REQUIRED COMPONENTS ${opencv_4_components})
 
 include_directories(include)
 

--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -33,10 +33,6 @@ if(ANDROID)
   return()
 endif()
 
-find_package(GTK3)
-add_definitions(-DHAVE_GTK)
-include_directories(${GTK3_INCLUDE_DIRS})
-
 add_library(image_view_nodes SHARED
   src/disparity_view_node.cpp
   src/extract_images_node.cpp
@@ -56,7 +52,6 @@ ament_target_dependencies(image_view_nodes
   stereo_msgs
 )
 target_link_libraries(image_view_nodes
-  ${GTK3_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
 )

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -18,7 +18,6 @@
 
   <depend>camera_calibration_parsers</depend>
   <depend>cv_bridge</depend>
-  <depend>gtk3</depend>
   <depend>image_transport</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
This PR reinstates OpenCV 3 compatibility.

While Foxy only supports Ubuntu 20.04 (and hence OpenCV 4), we still strive to maintain Ubuntu 18.04 (which has OpenCV 3).  In this case, it is trivial to keep keep image_pipeline working with OpenCV 3, so reintroduce compatibility with it.

Along with this, remove the dependency on GTK3.  It fails on Ubuntu 18.04, but it actually doesn't matter since there is no usage of the GTK API anywhere in the code.