### PR TITLE
Replacing deprecated header includes with new HPP versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   foxy:
     docker:
-      - image: jwhitleywork/ros:foxy-ros-base-focal
+      - image: ros:foxy-ros-base
     steps:
       - checkout
       - run:

--- a/depth_image_proc/src/convert_metric.cpp
+++ b/depth_image_proc/src/convert_metric.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <depth_image_proc/visibility.h>
 #include <cmath>

--- a/depth_image_proc/src/crop_foremost.cpp
+++ b/depth_image_proc/src/crop_foremost.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <depth_image_proc/visibility.h>

--- a/depth_image_proc/src/disparity.cpp
+++ b/depth_image_proc/src/disparity.cpp
@@ -30,8 +30,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <sensor_msgs/image_encodings.hpp>

--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_conversions.hpp>

--- a/depth_image_proc/src/point_cloud_xyz_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyz_radial.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -30,8 +30,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/depth_image_proc/src/point_cloud_xyzi_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi_radial.cpp
@@ -30,9 +30,9 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -30,8 +30,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -30,8 +30,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/image_proc/include/image_proc/crop_decimate.hpp
+++ b/image_proc/include/image_proc/crop_decimate.hpp
@@ -34,7 +34,7 @@
 #define IMAGE_PROC__CROP_DECIMATE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.hpp>
 

--- a/image_proc/include/image_proc/crop_non_zero.hpp
+++ b/image_proc/include/image_proc/crop_non_zero.hpp
@@ -34,7 +34,7 @@
 #define IMAGE_PROC__CROP_NON_ZERO_HPP_
 
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <thread>

--- a/image_proc/include/image_proc/debayer.hpp
+++ b/image_proc/include/image_proc/debayer.hpp
@@ -34,7 +34,7 @@
 #define IMAGE_PROC__DEBAYER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <ament_index_cpp/get_resource.hpp>
 
 #include <cstring>

--- a/image_proc/include/image_proc/rectify.hpp
+++ b/image_proc/include/image_proc/rectify.hpp
@@ -34,7 +34,7 @@
 #define IMAGE_PROC__RECTIFY_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <cv_bridge/cv_bridge.h>
 

--- a/image_proc/include/image_proc/resize.hpp
+++ b/image_proc/include/image_proc/resize.hpp
@@ -34,7 +34,7 @@
 #define IMAGE_PROC__RESIZE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <ament_index_cpp/get_resource.hpp>
 
 #include <cstring>

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -33,7 +33,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_geometry/pinhole_camera_model.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 #include <thread>
 #include <memory>

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -32,10 +32,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp/qos.hpp>
-#include <sensor_msgs/msg/camera_info.h>
-#include <sensor_msgs/msg/image.h>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 #include <memory>
 #include <mutex>

--- a/image_proc/test/rostest.cpp
+++ b/image_proc/test/rostest.cpp
@@ -32,10 +32,10 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#include <camera_calibration_parsers/parse.h>
+#include <camera_calibration_parsers/parse.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/highgui/highgui.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 #include <boost/foreach.hpp>
 

--- a/image_proc/test/test_rectify.cpp
+++ b/image_proc/test/test_rectify.cpp
@@ -32,12 +32,12 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#include <camera_calibration_parsers/parse.h>
+#include <camera_calibration_parsers/parse.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/highgui/highgui.hpp>
-#include <image_transport/image_transport.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/distortion_models.h>
+#include <image_transport/image_transport.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/distortion_models.hpp>
 
 #include <algorithm>
 #include <string>

--- a/image_publisher/include/image_publisher/image_publisher.hpp
+++ b/image_publisher/include/image_publisher/image_publisher.hpp
@@ -34,7 +34,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <image_publisher/visibility.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/highgui/highgui.hpp>
 #include <string>

--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -31,7 +31,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <camera_info_manager/camera_info_manager.h>
+#include <camera_info_manager/camera_info_manager.hpp>
 
 #include <chrono>
 #include <memory>

--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -36,7 +36,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/image_view/include/image_view/extract_images_node.hpp
+++ b/image_view/include/image_view/extract_images_node.hpp
@@ -50,7 +50,7 @@
 #define IMAGE_VIEW__EXTRACT_IMAGES_NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include <boost/format.hpp>

--- a/image_view/include/image_view/image_saver_node.hpp
+++ b/image_view/include/image_view/image_saver_node.hpp
@@ -52,7 +52,7 @@
 #include <boost/format.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <std_srvs/srv/trigger.hpp>
 

--- a/image_view/include/image_view/image_view_node.hpp
+++ b/image_view/include/image_view/image_view_node.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/msg/image.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <boost/format.hpp>

--- a/image_view/include/image_view/stereo_view_node.hpp
+++ b/image_view/include/image_view/stereo_view_node.hpp
@@ -52,7 +52,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/sync_policies/exact_time.h>

--- a/image_view/include/image_view/video_recorder_node.hpp
+++ b/image_view/include/image_view/video_recorder_node.hpp
@@ -16,7 +16,7 @@
 #define IMAGE_VIEW__VIDEO_RECORDER_NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 #include <opencv2/highgui/highgui.hpp>
 

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -50,7 +50,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/msg/image.hpp>
 

--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -54,7 +54,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <camera_calibration_parsers/parse.h>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <std_srvs/srv/trigger.hpp>

--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -53,7 +53,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <std_msgs/msg/header.hpp>
 

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -53,7 +53,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/sync_policies/exact_time.h>

--- a/image_view/src/video_recorder_node.cpp
+++ b/image_view/src/video_recorder_node.cpp
@@ -20,7 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <camera_calibration_parsers/parse.h>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -32,9 +32,9 @@
 #include <stereo_image_proc/stereo_processor.hpp>
 
 #include <cv_bridge/cv_bridge.h>
-#include <image_geometry/stereo_camera_model.h>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_geometry/stereo_camera_model.hpp>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -32,7 +32,7 @@
 #include <stereo_image_proc/stereo_processor.hpp>
 
 #include <cv_bridge/cv_bridge.h>
-#include <image_geometry/stereo_camera_model.hpp>
+#include <image_geometry/stereo_camera_model.h>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -29,9 +29,9 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <image_geometry/stereo_camera_model.h>
-#include <image_transport/image_transport.h>
-#include <image_transport/subscriber_filter.h>
+#include <image_geometry/stereo_camera_model.hpp>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -29,7 +29,7 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <image_geometry/stereo_camera_model.hpp>
+#include <image_geometry/stereo_camera_model.h>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
 #include <message_filters/subscriber.h>


### PR DESCRIPTION
Without this change, multiple deprecation warnings are generated on build.