### PR TITLE
[Dashing] Add rclcpp and rclcpp_components dependencies to package.xml.

### DIFF
--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -29,6 +29,8 @@
   <build_depend>image_transport</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>class_loader</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>stereo_msgs</build_depend>
   <build_depend>tf2</build_depend>
@@ -38,6 +40,8 @@
   <exec_depend>tf2_eigen</exec_depend>
   <exec_depend>image_geometry</exec_depend>
   <exec_depend>image_transport</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
 


### PR DESCRIPTION
I noticed that these are listed in CMakeLists.txt but not in package.xml
and this is causing a build failure for the binary releases on
build.ros2.org:

http://build.ros2.org/view/Dbin_ubhf_uBhf/job/Dbin_uB64__depth_image_proc__ubuntu_bionic_amd64__binary/