### PR TITLE
[Foxy] Use ament_auto Macros

### DIFF
--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -11,7 +11,7 @@
   <author>Patrick Mihelich</author>
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   
   <license>BSD</license>
   <url>http://www.ros.org/wiki/camera_calibration</url>

--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -12,7 +12,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://www.ros.org/wiki/camera_calibration</url>
+  <url type="website">https://index.ros.org/p/camera_calibration/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>James Bowman</author>

--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -7,14 +7,16 @@
      camera_calibration allows easy calibration of monocular or stereo
      cameras using a checkerboard calibration target. 
   </description>
-  <author>James Bowman</author>
-  <author>Patrick Mihelich</author>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
-  
   <license>BSD</license>
-  <url>http://www.ros.org/wiki/camera_calibration</url>
+  <url type="website">http://www.ros.org/wiki/camera_calibration</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
+  <author>James Bowman</author>
+  <author>Patrick Mihelich</author>
 
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>

--- a/camera_calibration/setup.py
+++ b/camera_calibration/setup.py
@@ -5,7 +5,7 @@ PACKAGE_NAME = "camera_calibration"
 
 setup(
     name=PACKAGE_NAME,
-    version='1.12.23',
+    version='2.2.0',
     packages=["camera_calibration", "camera_calibration.nodes"],
     data_files=[
     ('share/ament_index/resource_index/packages',
@@ -19,8 +19,8 @@ setup(
     ],
     zip_safe=True,
     author='James Bowman, Patrick Mihelich',
-    maintainer='Vincent Rabaud, Steven Macenski',
-    maintainer_email='vincent.rabaud@gmail.com, stevenmacenski@gmail.com, software@autonomoustuff.com',
+    maintainer='Vincent Rabaud, Steven Macenski, Joshua Whitley',
+    maintainer_email='vincent.rabaud@gmail.com, stevenmacenski@gmail.com, whitleysoftwareservices@gmail.com',
     keywords=['ROS2'],
     description='Camera_calibration allows easy calibration of monocular or stereo cameras using a checkerboard calibration target .',
     license='BSD',

--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -10,29 +10,19 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(tf2_eigen REQUIRED)
-find_package(image_geometry REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(message_filters REQUIRED)
-find_package(class_loader REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(stereo_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 QUIET)
 if(NOT EIGEN3_FOUND)
   find_package(Eigen REQUIRED)
   set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+  include_directories(include ${EIGEN3_INCLUDE_DIRS})
 endif()
-find_package(OpenCV REQUIRED)
-include_directories(include ${BOOST_INCLUDE_DIRS} ${rclcpp_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} SHARED
+find_package(OpenCV REQUIRED)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/convert_metric.cpp
   src/crop_foremost.cpp
   src/disparity.cpp
@@ -43,47 +33,24 @@ add_library(${PROJECT_NAME} SHARED
   src/point_cloud_xyzi_radial.cpp
   src/register.cpp
 )
-ament_target_dependencies(${PROJECT_NAME}
-  "image_transport"
-  "image_geometry"
-  "cv_bridge"
-  "class_loader"
-  "message_filters"
-  "rclcpp"
-  "rclcpp_components"
-  "tf2_ros"
-  "tf2"
-  "tf2_eigen"
-  "stereo_msgs"
-  "sensor_msgs"
+
+rclcpp_components_register_nodes(${PROJECT_NAME}
+  "${PROJECT_NAME}::ConvertMetricNode"
+  "${PROJECT_NAME}::CropForemostNode"
+  "${PROJECT_NAME}::DisparityNode"
+  "${PROJECT_NAME}::PointCloudXyzNode"
+  "${PROJECT_NAME}::PointCloudXyzRadialNode"
+  "${PROJECT_NAME}::PointCloudXyziNode"
+  "${PROJECT_NAME}::PointCloudXyziRadialNode"
+  "${PROJECT_NAME}::PointCloudXyzrgbNode"
+  "${PROJECT_NAME}::RegisterNode"
 )
 
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::ConvertMetricNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::CropForemostNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::DisparityNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::PointCloudXyzNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::PointCloudXyzRadialNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::PointCloudXyziNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::PointCloudXyziRadialNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::PointCloudXyzrgbNode")
-rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::RegisterNode")
-
-target_link_libraries(${PROJECT_NAME} ${ament_LIBRARIES} ${OpenCV_LIBRARIES})
-
-install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION include/${PROJECT_NAME}
-    FILES_MATCHING PATTERN "*.h")
-
-install(TARGETS ${PROJECT_NAME}
-        DESTINATION lib
-)
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
-)
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -17,7 +17,7 @@
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <maintainer email="chris.ye@intel.com">Chris Ye</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/depth_image_proc</url>
+  <url type="website">https://index.ros.org/p/depth_image_proc/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -1,4 +1,6 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>depth_image_proc</name>
   <version>2.2.0</version>
   <description>
@@ -9,41 +11,35 @@
      a depth image into another camera frame.
 
   </description>
-  <author>Patrick Mihelich</author>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <maintainer email="chris.ye@intel.com">Chris Ye</maintainer>
   <license>BSD</license>
-  <url>http://ros.org/wiki/depth_image_proc</url>
+  <url type="website">http://ros.org/wiki/depth_image_proc</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
+  <author>Patrick Mihelich</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>tf2_eigen</build_depend>
-  <build_depend>image_geometry</build_depend>
-  <build_depend>image_transport</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>class_loader</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>stereo_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>
 
-  <exec_depend>cv_bridge</exec_depend>
-  <exec_depend>tf2_eigen</exec_depend>
-  <exec_depend>image_geometry</exec_depend>
-  <exec_depend>image_transport</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
+  <depend>cv_bridge</depend>
+  <depend>image_geometry</depend>
+  <depend>image_transport</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>stereo_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/image_pipeline/CMakeLists.txt
+++ b/image_pipeline/CMakeLists.txt
@@ -11,4 +11,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/image_pipeline/package.xml
+++ b/image_pipeline/package.xml
@@ -26,6 +26,10 @@
   <exec_depend>image_view</exec_depend>
   <exec_depend>stereo_image_proc</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/image_pipeline/package.xml
+++ b/image_pipeline/package.xml
@@ -1,31 +1,32 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>image_pipeline</name>
   <version>2.2.0</version>
   <description>image_pipeline fills the gap between getting raw images from a camera driver and higher-level vision processing.</description>
-  <author>Patrick Mihelich</author>
-  <author>James Bowman</author>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  
   <url type="website">http://www.ros.org/wiki/image_pipeline</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
+  <author>Patrick Mihelich</author>
+  <author>James Bowman</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!-- stack contents -->
-  <run_depend>camera_calibration</run_depend>
-  <run_depend>depth_image_proc</run_depend>
-  <run_depend>image_proc</run_depend>
-  <run_depend>image_publisher</run_depend>
-  <run_depend>image_rotate</run_depend>
-  <!-- <run_depend>image_view</run_depend> -->
-  <!-- <run_depend>stereo_image_proc</run_depend> -->
+  <exec_depend>camera_calibration</exec_depend>
+  <exec_depend>depth_image_proc</exec_depend>
+  <exec_depend>image_proc</exec_depend>
+  <exec_depend>image_publisher</exec_depend>
+  <exec_depend>image_rotate</exec_depend>
+  <exec_depend>image_view</exec_depend>
+  <exec_depend>stereo_image_proc</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/image_pipeline/package.xml
+++ b/image_pipeline/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://www.ros.org/wiki/image_pipeline</url>
+  <url type="website">https://index.ros.org/p/image_pipeline/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-
 project(image_proc)
 
 # ROS2 Flags
@@ -11,145 +10,86 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(rcutils REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(sensor_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
 find_package(OpenCV REQUIRED)
 if(OpenCV_VERSION VERSION_LESS "3.2.0")
   message(FATAL "Minimum OpenCV version is 3.2.0 (found version ${OpenCV_VERSION})")
 endif()
-find_package(image_geometry REQUIRED)
 
-include_directories(
-  include
-)
-
-set(dependencies
-  image_geometry
-  sensor_msgs
-  cv_bridge
-  class_loader
-  image_transport
-  rclcpp
-  rclcpp_components
-  rcutils
-)
-
-add_library(${PROJECT_NAME} SHARED
+# image_proc library
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/processor.cpp
 )
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(${PROJECT_NAME}
-  image_geometry
-  rcutils
-  sensor_msgs
-)
 
-add_library(rectify SHARED
+# rectify library
+ament_auto_add_library(rectify SHARED
   src/rectify.cpp)
 target_compile_definitions(rectify
-  PRIVATE "COMPOSITION_BUILDING_DLL")
-
-ament_target_dependencies(rectify
-  ${dependencies}
+  PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-
 rclcpp_components_register_nodes(rectify "image_proc::RectifyNode")
 set(node_plugins "${node_plugins}image_proc::RectifyNode;$<TARGET_FILE:rectify>\n")
 
-add_library(debayer SHARED
+# debayer library
+ament_auto_add_library(debayer SHARED
   src/debayer.cpp
   src/edge_aware.cpp
 )
-
 target_compile_definitions(debayer
-  PRIVATE "COMPOSITION_BUILDING_DLL")
-
-ament_target_dependencies(debayer
-  ${dependencies}
+  PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-
 rclcpp_components_register_nodes(debayer "image_proc::DebayerNode")
 set(node_plugins "${node_plugins}image_proc::DebayerNode;$<TARGET_FILE:debayer>\n")
 
-add_library(resize SHARED
+# resize library
+ament_auto_add_library(resize SHARED
   src/resize.cpp
 )
-
 target_compile_definitions(resize
-  PRIVATE "COMPOSITION_BUILDING_DLL")
-
-ament_target_dependencies(resize
-  ${dependencies}
+  PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-
 rclcpp_components_register_nodes(resize "image_proc::ResizeNode")
 set(node_plugins "${node_plugins}image_proc::ResizeNode;$<TARGET_FILE:resize>\n")
 
-add_library(crop_decimate SHARED
+# crop_decimate library
+ament_auto_add_library(crop_decimate SHARED
   src/crop_decimate.cpp
 )
-
 target_compile_definitions(crop_decimate
-  PRIVATE "COMPOSITION_BUILDING_DLL")
-
-ament_target_dependencies(crop_decimate
-  ${dependencies}
+  PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-
 rclcpp_components_register_nodes(crop_decimate "image_proc::CropDecimateNode")
 set(node_plugins "${node_plugins}image_proc::CropDecimateNode;$<TARGET_FILE:crop_decimate>\n")
-add_library(crop_non_zero SHARED
+
+# crop_non_zero library
+ament_auto_add_library(crop_non_zero SHARED
   src/crop_non_zero.cpp
 )
-
 target_compile_definitions(crop_non_zero
-  PRIVATE "COMPOSITION_BUILDING_DLL")
-
-ament_target_dependencies(crop_non_zero
-  ${dependencies}
+  PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-
 rclcpp_components_register_nodes(crop_non_zero "image_proc::CropNonZeroNode")
 set(node_plugins "${node_plugins}image_proc::CropNonZeroNode;$<TARGET_FILE:crop_non_zero>\n")
 
-add_executable(image_proc_exe
+# image_proc example node
+ament_auto_add_executable(image_proc_exe
   src/image_proc.cpp
 )
-
 target_link_libraries(image_proc_exe
   debayer
   rectify
   ament_index_cpp::ament_index_cpp
 )
+set_target_properties(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_libraries(image_proc "stdc++fs")
 endif()
-
-ament_target_dependencies(image_proc_exe
-  ${dependencies}
-)
-
-set_target_properties(image_proc_exe PROPERTIES OUTPUT_NAME image_proc)
-
-install(TARGETS
-  ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 install(TARGETS image_proc_exe
   ARCHIVE DESTINATION lib
@@ -157,73 +97,9 @@ install(TARGETS image_proc_exe
   RUNTIME DESTINATION bin
 )
 
-install(
-  TARGETS crop_decimate
-  EXPORT export_crop_decimate
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-install(
-  TARGETS crop_non_zero
-  EXPORT export_crop_non_zero
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-install(
-  TARGETS debayer
-  EXPORT export_debayer
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-install(
-  TARGETS rectify
-  EXPORT export_rectify
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-install(
-  TARGETS resize
-  EXPORT export_resize
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
-install(DIRECTORY include/
-  DESTINATION include
-)
-
-install(DIRECTORY launch/
-  DESTINATION share/${PROJECT_NAME}
-)
-
-ament_export_include_directories(include)
-
-ament_export_interfaces(
-  export_${PROJECT_NAME} HAS_LIBRARY_TARGET
-  export_crop_decimate HAS_LIBRARY_TARGET
-  export_crop_non_zero HAS_LIBRARY_TARGET
-  export_debayer HAS_LIBRARY_TARGET
-  export_rectify HAS_LIBRARY_TARGET
-  export_resize HAS_LIBRARY_TARGET
-)
-
-ament_export_libraries(
-  ${PROJECT_NAME}
-  crop_decimate
-  crop_non_zero
-  debayer
-  rectify
-  resize
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://www.ros.org/wiki/image_proc</url>
+  <url type="website">https://index.ros.org/p/image_proc/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -7,26 +7,25 @@
 
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
-
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url>http://www.ros.org/wiki/image_proc</url>
-
+  <url type="website">http://www.ros.org/wiki/image_proc</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>
   <author>Kurt Konolige</author>
   <author>Jeremy Leibs</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>cv_bridge</depend>
+  <depend>image_geometry</depend>
+  <depend>image_transport</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rcutils</depend>
-  <depend>cv_bridge</depend>
-  <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
-  <depend>image_geometry</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   

--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -10,62 +10,22 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(camera_info_manager REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(class_loader REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(image_geometry REQUIRED)
-find_package(rclcpp_components REQUIRED)
-
-set( DEPENDENCIES
-  rclcpp
-  rclcpp_components
-  image_geometry
-  class_loader
-  image_transport
-  camera_info_manager
-  cv_bridge
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(OpenCV REQUIRED COMPONENTS core imgcodecs videoio)
 message(STATUS "opencv version ${OpenCV_VERSION}")
 
-include_directories(include)
-
-add_library(image_publisher SHARED src/image_publisher.cpp)
-target_link_libraries(image_publisher ${ament_LIBRARIES} ${OpenCV_LIBRARIES})
-ament_target_dependencies(image_publisher
-  ${DEPENDENCIES}
-)
-
+ament_auto_add_library(image_publisher SHARED src/image_publisher.cpp)
+target_link_libraries(image_publisher ${OpenCV_LIBRARIES})
 rclcpp_components_register_nodes(image_publisher "${PROJECT_NAME}::ImagePublisher")
 set(node_plugins "${node_plugins}${PROJECT_NAME}::ImagePublisher;$<TARGET_FILE:ImagePublisher>\n")
 
-install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION include/${PROJECT_NAME}
-    FILES_MATCHING PATTERN "*.h")
-
-add_executable(image_publisher_node src/image_publisher_node.cpp)
-target_link_libraries(image_publisher_node ${ament_LIBRARIES} image_publisher)
-ament_target_dependencies(image_publisher_node
-  ${DEPENDENCIES})
-
-install(TARGETS image_publisher_node
-        DESTINATION lib/${PROJECT_NAME}
-)
-install(TARGETS image_publisher
-        DESTINATION lib/${PROJECT_NAME}
-)
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
-)
+ament_auto_add_executable(image_publisher_node src/image_publisher_node.cpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(${DEPENDENCIES})
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/image_publisher/package.xml
+++ b/image_publisher/package.xml
@@ -15,7 +15,7 @@
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <maintainer email="chris.ye@intel.com">Chris Ye</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/image_publisher</url>
+  <url type="website">https://index.ros.org/p/image_publisher/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Kei Okada</author>

--- a/image_publisher/package.xml
+++ b/image_publisher/package.xml
@@ -1,41 +1,38 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>image_publisher</name>
   <version>2.2.0</version>
   <description>
-    <p>
+
       Contains a node publish an image stream from single image file
       or avi motion file.
-    </p>
+
   </description>
-  <author>Kei Okada</author>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <maintainer email="chris.ye@intel.com">Chris Ye</maintainer>
   <license>BSD</license>
-  <url>http://ros.org/wiki/image_publisher</url>
+  <url type="website">http://ros.org/wiki/image_publisher</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
+  <author>Kei Okada</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <depend>camera_info_manager</depend>
+  <depend>class_loader</depend>
+  <depend>cv_bridge</depend>
+  <depend>image_geometry</depend>
+  <depend>image_transport</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>camera_info_manager</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>image_geometry</build_depend>
-  <build_depend>class_loader</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-
-  <exec_depend>cv_bridge</exec_depend>
-  <exec_depend>camera_info_manager</exec_depend>
-  <exec_depend>image_transport</exec_depend>
-  <exec_depend>image_geometry</exec_depend>
-  <exec_depend>class_loader</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/image_rotate/CMakeLists.txt
+++ b/image_rotate/CMakeLists.txt
@@ -10,56 +10,23 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(class_loader REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
 find_package(OpenCV REQUIRED core imgproc)
 
-# add the executable
-include_directories(include)
-
-add_library(${PROJECT_NAME} SHARED src/image_rotate_node.cpp)
-target_link_libraries(${PROJECT_NAME} ${ament_LIBRARIES} ${OpenCV_LIBRARIES})
-ament_target_dependencies(${PROJECT_NAME}
-  "image_transport"
-  "cv_bridge"
-  "class_loader"
-  "rclcpp_components"
-  "rclcpp"
-  "rclcpp_components"
-  "tf2_ros"
-  "tf2_geometry_msgs"
-)
+ament_auto_add_library(${PROJECT_NAME} SHARED src/image_rotate_node.cpp)
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
 rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::ImageRotateNode")
 set(node_plugins "${node_plugins}${PROJECT_NAME}::ImageRotateNode;$<TARGET_FILE:ImageRotateNode>\n")
 
-install(TARGETS ${PROJECT_NAME}
-        DESTINATION lib
-)
-
-add_executable(image_rotate_bin src/image_rotate.cpp)
+ament_auto_add_executable(image_rotate_bin src/image_rotate.cpp)
 set_target_properties(image_rotate_bin PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
-target_link_libraries(image_rotate_bin ${ament_LIBRARIES} ${OpenCV_LIBRARIES} ${PROJECT_NAME})
-ament_target_dependencies(image_rotate_bin
-  "rclcpp")
-
-install(TARGETS image_rotate_bin
-        DESTINATION lib/${PROJECT_NAME}
-)
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
-)
+target_link_libraries(image_rotate_bin ${OpenCV_LIBRARIES} ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -28,7 +28,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/image_rotate</url>
+  <url type="website">https://index.ros.org/p/image_rotate/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Blaise Gassend</author>

--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -1,4 +1,6 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>image_rotate</name>
   <version>2.2.0</version>
   <description>
@@ -21,18 +23,17 @@
       borders, and does not output a camera_info.
     </p>
   </description>
-  <author>Blaise Gassend</author>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url>http://ros.org/wiki/image_rotate</url>
+  <url type="website">http://ros.org/wiki/image_rotate</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
+  <author>Blaise Gassend</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>class_loader</build_depend>
 
@@ -43,6 +44,9 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -9,31 +9,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(camera_calibration_parsers REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(message_filters REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(stereo_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
-
-include_directories(
-  include
-  ${Boost_INCLUDE_DIRS}
-  ${OpenCV_INCLUDE_DIRS}
-)
 
 # Deal with the GUI's
 if(ANDROID)
   return()
 endif()
 
-add_library(image_view_nodes SHARED
+ament_auto_add_library(${PROJECT_NAME}_nodes SHARED
   src/disparity_view_node.cpp
   src/extract_images_node.cpp
   src/image_view_node.cpp
@@ -41,123 +28,82 @@ add_library(image_view_nodes SHARED
   src/stereo_view_node.cpp
   src/video_recorder_node.cpp
 )
-ament_target_dependencies(image_view_nodes
-  camera_calibration_parsers
-  cv_bridge
-  image_transport
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  std_srvs
-  stereo_msgs
-)
-target_link_libraries(image_view_nodes
+target_link_libraries(${PROJECT_NAME}_nodes
   ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
 )
-target_compile_definitions(image_view_nodes
+target_compile_definitions(${PROJECT_NAME}_nodes
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::DisparityViewNode"
+rclcpp_components_register_nodes(${PROJECT_NAME}_nodes
+  "${PROJECT_NAME}::DisparityViewNode"
+  "${PROJECT_NAME}::ExtractImagesNode"
+  "${PROJECT_NAME}::ImageViewNode"
+  "${PROJECT_NAME}::ImageSaverNode"
+  "${PROJECT_NAME}::StereoViewNode"
+  "${PROJECT_NAME}::VideoRecorderNode"
 )
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::ExtractImagesNode"
-)
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::ImageViewNode"
-)
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::ImageSaverNode"
-)
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::StereoViewNode"
-)
-rclcpp_components_register_nodes(image_view_nodes
-  "image_view::VideoRecorderNode"
-)
-ament_export_include_directories(include)
-ament_export_interfaces(export_image_view_nodes)
-ament_export_libraries(image_view_nodes)
 
 # Image viewers
-add_executable(disparity_view
+ament_auto_add_executable(disparity_view
   src/disparity_view.cpp
 )
-ament_target_dependencies(disparity_view
-  rclcpp
-)
 target_link_libraries(disparity_view
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 add_dependencies(disparity_view
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 
-add_executable(image_view
+ament_auto_add_executable(${PROJECT_NAME}
   src/image_view.cpp
 )
-ament_target_dependencies(image_view
-  rclcpp
+target_link_libraries(${PROJECT_NAME}
+  ${PROJECT_NAME}_nodes
 )
-target_link_libraries(image_view
-  image_view_nodes
-)
-add_dependencies(image_view
-  image_view_nodes
+add_dependencies(${PROJECT_NAME}
+  ${PROJECT_NAME}_nodes
 )
 
-add_executable(stereo_view
+ament_auto_add_executable(stereo_view
   src/stereo_view.cpp
 )
-ament_target_dependencies(stereo_view
-  rclcpp
-)
 target_link_libraries(stereo_view
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 add_dependencies(stereo_view
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 
 # Other Tools
-add_executable(extract_images
+ament_auto_add_executable(extract_images
   src/extract_images.cpp
 )
-ament_target_dependencies(extract_images
-  rclcpp
-)
 target_link_libraries(extract_images
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 add_dependencies(extract_images
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 
-add_executable(image_saver
+ament_auto_add_executable(image_saver
   src/image_saver.cpp
 )
-ament_target_dependencies(image_saver
-  rclcpp
-)
 target_link_libraries(image_saver
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 add_dependencies(image_saver
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 
-add_executable(video_recorder
+ament_auto_add_executable(video_recorder
   src/video_recorder.cpp
 )
-ament_target_dependencies(video_recorder
-  rclcpp
-)
 target_link_libraries(video_recorder
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 add_dependencies(video_recorder
-  image_view_nodes
+  ${PROJECT_NAME}_nodes
 )
 
 if(BUILD_TESTING)
@@ -165,32 +111,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-install(
-  TARGETS
-    disparity_view
-    extract_images
-    image_saver
-    image_view
-    stereo_view
-    video_recorder
-  DESTINATION lib/${PROJECT_NAME}
-)
-
-install(DIRECTORY include/
-  DESTINATION include
-)
-
-install(TARGETS image_view_nodes
-  EXPORT export_image_view_nodes
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
-# Python programs
-#catkin_install_python(
-#  PROGRAMS scripts/extract_images_sync
-#  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-#)
-
-ament_package()
+ament_auto_package()

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -12,7 +12,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://www.ros.org/wiki/image_view</url>
+  <url type="website">https://index.ros.org/p/image_view/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -7,25 +7,28 @@
   A simple viewer for ROS image topics. Includes a specialized viewer
   for stereo + disparity images.
   </description>
+
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url>http://www.ros.org/wiki/image_view</url>
+  <url type="website">http://www.ros.org/wiki/image_view</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>camera_calibration_parsers</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
+  <depend>libboost-dev</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>stereo_msgs</depend>
-  <depend>boost</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -111,7 +111,7 @@ void ExtractImagesNode::image_cb(const sensor_msgs::msg::Image::ConstSharedPtr &
   cv::Mat image;
   try {
     image = cv_bridge::toCvShare(msg, "bgr8")->image;
-  } catch (cv_bridge::Exception) {
+  } catch (const cv_bridge::Exception &) {
     RCLCPP_ERROR(this->get_logger(), "Unable to convert %s image to bgr8", msg->encoding.c_str());
   }
 

--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -109,7 +109,7 @@ bool ImageSaverNode::saveImage(
   cv::Mat image;
   try {
     image = cv_bridge::toCvShare(image_msg, encoding)->image;
-  } catch (cv_bridge::Exception) {
+  } catch (const cv_bridge::Exception &) {
     RCLCPP_ERROR(
       this->get_logger(), "Unable to convert %s image to %s",
       image_msg->encoding.c_str(), encoding.c_str());

--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -52,7 +52,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <camera_calibration_parsers/parse.h>
+#include <camera_calibration_parsers/parse.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>

--- a/image_view/src/video_recorder_node.cpp
+++ b/image_view/src/video_recorder_node.cpp
@@ -134,7 +134,7 @@ void VideoRecorderNode::callback(const sensor_msgs::msg::Image::ConstSharedPtr &
     } else {
       RCLCPP_WARN(this->get_logger(), "Frame skipped, no data!");
     }
-  } catch (cv_bridge::Exception) {
+  } catch (const cv_bridge::Exception &) {
     RCLCPP_ERROR(
       this->get_logger(),
       "Unable to convert %s image to %s",

--- a/image_view/src/video_recorder_node.cpp
+++ b/image_view/src/video_recorder_node.cpp
@@ -18,7 +18,7 @@
 #include <opencv2/videoio.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <camera_calibration_parsers/parse.h>
+#include <camera_calibration_parsers/parse.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.hpp>
 #include <rclcpp_components/register_node_macro.hpp>

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -9,43 +9,21 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(cv_bridge REQUIRED)
-find_package(image_geometry REQUIRED)
-find_package(image_proc REQUIRED)
-find_package(image_transport REQUIRED)
-find_package(message_filters REQUIRED)
-find_package(OpenCV REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(stereo_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-include_directories(
-  include
-  ${OpenCV_INCLUDE_DIRS}
-)
+find_package(OpenCV REQUIRED)
 
 # See note in image_proc/CMakeLists.txt
 # add_definitions(-DOPENCV_TRAITS_ENABLE_DEPRECATED)
 
-add_library(${PROJECT_NAME} SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/stereo_processor.cpp
   src/${PROJECT_NAME}/disparity_node.cpp
   src/${PROJECT_NAME}/point_cloud_node.cpp
 )
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
-)
-ament_target_dependencies(${PROJECT_NAME}
-  cv_bridge
-  image_geometry
-  image_proc
-  image_transport
-  message_filters
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  stereo_msgs
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
@@ -57,29 +35,8 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE point_cloud_node
 )
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY include/
-  DESTINATION include
-)
-
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
-
 if(BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-  find_package(launch_testing_ament_cmake REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  find_package(python_cmake_module REQUIRED)
-
   ament_lint_auto_find_test_dependencies()
 
   set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
@@ -107,4 +64,4 @@ if(BUILD_TESTING)
   set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 endif()
 
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/stereo_image_proc/package.xml
+++ b/stereo_image_proc/package.xml
@@ -1,17 +1,22 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>stereo_image_proc</name>
   <version>2.2.0</version>
   <description>Stereo and single image rectification and disparity processing.</description>
+
+  <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
+  <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
+  <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
+  <license>BSD</license>
+  <url type="website">http://www.ros.org/wiki/stereo_image_proc</url>
+  <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
+  <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>
   <author>Kurt Konolige</author>
   <author>Jeremy Leibs</author>
-  <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
-  <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
-  <maintainer email="software@autonomoustuff.com">Autonomoustuff team</maintainer>
-  <license>BSD</license>
-  <url>http://www.ros.org/wiki/stereo_image_proc</url>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>
@@ -30,8 +35,8 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
-  <test_depend>python_cmake_module</test_depend>
   <test_depend>python3-opencv</test_depend>
+  <test_depend>python_cmake_module</test_depend>
   <test_depend>rclpy</test_depend>
 
   <export>

--- a/stereo_image_proc/package.xml
+++ b/stereo_image_proc/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steven Macenski</maintainer>
   <maintainer email="whitleysoftwareservices@gmail.com">Joshua Whitley</maintainer>
   <license>BSD</license>
-  <url type="website">http://www.ros.org/wiki/stereo_image_proc</url>
+  <url type="website">https://index.ros.org/p/stereo_image_proc/github-ros-perception-image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>


### PR DESCRIPTION
This PR applies the macros from `ament_cmake_auto` to all packages in this repository as well as fixing some other minor quirks (updating email addresses, package version mismatches, minor build warnings, etc.). Part of #571 but doesn't close it because this should be done for Dashing too.