### PR TITLE
Fix calibration yaml formatting

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -654,7 +654,7 @@ class Calibrator(object):
             "  rows: 3",
             "  cols: 3",
             "  data: " + format_mat(k, 5),
-            "camera_model: " + dist_model,
+            "distortion_model: " + dist_model,
             "distortion_coefficients:",
             "  rows: 1",
             "  cols: %d" % d.size,


### PR DESCRIPTION
This PR fixes formatting of calibration tool yaml.

camera_model -> distortion_model

This issue was introduced in #440
