### PR TITLE
Refactor image_proc and stereo_image_proc launch files

### DIFF
--- a/image_proc/launch/image_proc.launch.py
+++ b/image_proc/launch/image_proc.launch.py
@@ -35,12 +35,9 @@ from launch.actions import DeclareLaunchArgument
 from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-
-from launch.actions import LogInfo
 
 
 def generate_launch_description():

--- a/image_proc/launch/image_proc.launch.py
+++ b/image_proc/launch/image_proc.launch.py
@@ -31,54 +31,77 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from launch import LaunchDescription
-from launch_ros import actions
-
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import LaunchConfigurationEquals
+from launch.conditions import LaunchConfigurationNotEquals
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PythonExpression
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+
+from launch.actions import LogInfo
 
 
 def generate_launch_description():
-    ld = LaunchDescription()
+    composable_nodes = [
+        ComposableNode(
+            package='image_proc',
+            plugin='image_proc::DebayerNode',
+            name='debayer_node',
+        ),
+        ComposableNode(
+            package='image_proc',
+            plugin='image_proc::RectifyNode',
+            name='rectify_mono_node',
+            # Remap subscribers and publishers
+            remappings=[
+                ('image', 'image_mono'),
+                ('camera_info', 'camera_info'),
+                ('image_rect', 'image_rect')
+            ],
+        ),
+        ComposableNode(
+            package='image_proc',
+            plugin='image_proc::RectifyNode',
+            name='rectify_color_node',
+            # Remap subscribers and publishers
+            remappings=[
+                ('image', 'image_color'),
+                ('image_rect', 'image_rect_color')
+            ],
+        )
+    ]
 
-    # Load composable container
-    image_processing = actions.ComposableNodeContainer(
-        node_name='image_proc_container',
+    arg_container = DeclareLaunchArgument(
+        name='container', default_value='',
+        description=(
+            'Name of an existing node container to load launched nodes into. '
+            'If unset, a new container will be created.'
+        )
+    )
+
+    # If an existing container is not provided, start a container and load nodes into it
+    image_processing_container = ComposableNodeContainer(
+        condition=LaunchConfigurationEquals('container', ''),
+        name='image_proc_container',
+        namespace='',
         package='rclcpp_components',
-        node_executable='component_container',
-        composable_node_descriptions=[
-            ComposableNode(
-                package='image_proc',
-                node_plugin='image_proc::DebayerNode',
-                node_name='debayer_node',
-            ),
-            # Example of rectifying an image
-            ComposableNode(
-                package='image_proc',
-                node_plugin='image_proc::RectifyNode',
-                node_name='rectify_mono_node',
-                # Remap subscribers and publishers
-                remappings=[
-                    # Subscriber remap
-                    ('image', 'image_mono'),
-                    ('camera_info', 'camera_info'),
-                    ('image_rect', 'image_rect')
-                ],
-            ),
-            # Example of rectifying an image
-            ComposableNode(
-                package='image_proc',
-                node_plugin='image_proc::RectifyNode',
-                node_name='rectify_color_node',
-                # Remap subscribers and publishers
-                remappings=[
-                    # Subscriber remap
-                    ('image', 'image_color'),
-                    # Publisher remap
-                    ('image_rect', 'image_rect_color')
-                ],
-            )],
+        executable='component_container',
+        composable_node_descriptions=composable_nodes,
         output='screen'
     )
 
-    ld.add_action(image_processing)
+    # If an existing container name is provided, load composable nodes into it
+    # This will block until a container with the provided name is available and nodes are loaded
+    load_composable_nodes = LoadComposableNodes(
+        condition=LaunchConfigurationNotEquals('container', ''),
+        composable_node_descriptions=composable_nodes,
+        target_container=LaunchConfiguration('container'),
+    )
 
-    return ld
+    return LaunchDescription([
+        arg_container,
+        image_processing_container,
+        load_composable_nodes,
+    ])

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -55,7 +55,13 @@ def generate_launch_description():
             parameters=[{
                 'approximate_sync': LaunchConfiguration('approximate_sync'),
                 'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
-            }]
+            }],
+            remappings=[
+                ('left/image_rect', [LaunchConfiguration('left_namespace'), '/image_rect']),
+                ('left/camera_info', [LaunchConfiguration('left_namespace'), '/camera_info']),
+                ('right/image_rect', [LaunchConfiguration('right_namespace'), '/image_rect']),
+                ('right/camera_info', [LaunchConfiguration('right_namespace'), '/camera_info']),
+            ]
         ),
         ComposableNode(
             package='stereo_image_proc',
@@ -63,7 +69,15 @@ def generate_launch_description():
             parameters=[{
                 'approximate_sync': LaunchConfiguration('approximate_sync'),
                 'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
-            }]
+            }],
+            remappings=[
+                ('left/camera_info', [LaunchConfiguration('left_namespace'), '/camera_info']),
+                ('right/camera_info', [LaunchConfiguration('right_namespace'), '/camera_info']),
+                (
+                    'left/image_rect_color',
+                    [LaunchConfiguration('left_namespace'), '/image_rect_color']
+                ),
+            ]
         ),
     ]
 

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -34,13 +34,11 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
-from launch.actions import LogInfo
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.actions import PushRosNamespace
@@ -104,7 +102,8 @@ def generate_launch_description():
             composable_node_descriptions=composable_nodes,
             target_container=LaunchConfiguration('container'),
         ),
-        # If a container name is not provided, set the name of the container launched above for image_proc nodes
+        # If a container name is not provided,
+        # set the name of the container launched above for image_proc nodes
         SetLaunchConfiguration(
             condition=LaunchConfigurationEquals('container', ''),
             name='container',

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -77,10 +77,12 @@ def generate_launch_description():
             description='Use the RMW QoS settings for the image and camera info subscriptions.'
         ),
         DeclareLaunchArgument(
-            name='left', default_value='left', description='Namespace for the left camera'
+            name='left_namespace', default_value='left',
+            description='Namespace for the left camera'
         ),
         DeclareLaunchArgument(
-            name='right', default_value='right', description='Namespace for the right camera'
+            name='right_namespace', default_value='right',
+            description='Namespace for the right camera'
         ),
         DeclareLaunchArgument(
             name='container', default_value='',
@@ -110,7 +112,7 @@ def generate_launch_description():
             value='stereo_image_proc_container'
         ),
         GroupAction([
-            PushRosNamespace(LaunchConfiguration('left')),
+            PushRosNamespace(LaunchConfiguration('left_namespace')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([
                     FindPackageShare('image_proc'), '/launch/image_proc.launch.py'
@@ -119,7 +121,7 @@ def generate_launch_description():
             ),
         ]),
         GroupAction([
-            PushRosNamespace(LaunchConfiguration('right')),
+            PushRosNamespace(LaunchConfiguration('right_namespace')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([
                     FindPackageShare('image_proc'), '/launch/image_proc.launch.py'

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -104,13 +104,12 @@ def generate_launch_description():
             composable_node_descriptions=composable_nodes,
             target_container=LaunchConfiguration('container'),
         ),
-        # Set the name of the container for included image_proc containers if one is not provided
+        # If a container name is not provided, set the name of the container launched above for image_proc nodes
         SetLaunchConfiguration(
             condition=LaunchConfigurationEquals('container', ''),
             name='container',
             value='stereo_image_proc_container'
         ),
-        LogInfo(msg=LaunchConfiguration('container')),
         GroupAction([
             PushRosNamespace(LaunchConfiguration('left')),
             IncludeLaunchDescription(


### PR DESCRIPTION
* Allow passing container name to image_proc launch file.
If a container name is provided, then load the image_proc nodes into that container. Otherwise, launch a container to load the nodes into.
* Include the image_proc launch file in the stereo_image_proc launch file
This resolves a TODO, making the launch file have similar behavior as the version from ROS 1.
Also expose a new launch argument for optionally providing a container (similar to image_proc's launch file).

---

These changes takes advantage of new launch conditions introduced in https://github.com/ros2/launch/pull/453. Therefore, if we want this change to be compatible with Foxy, we should backport the launch additions. I'm indifferent if this change is backported to Foxy, but if it is desired I can make the backport of the launch PR.

