### PR TITLE
Add pytest.ini to fix warning

### DIFF
--- a/camera_calibration/pytest.ini
+++ b/camera_calibration/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Fixes the following warning:

    Warning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
    Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.

