### PR TITLE
[image_view] Warn when filename_format is invalid

### DIFF
--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -260,7 +260,16 @@ void ImageNodelet::mouseCb(int event, int x, int y, int flags, void* param)
     return;
   }
 
-  std::string filename = (this_->filename_format_ % this_->count_).str();
+  std::string filename;
+  try
+  {
+    filename = (this_->filename_format_ % this_->count_).str();
+  }
+  catch (const boost::io::too_many_args&)
+  {
+    NODELET_WARN_ONCE("Couldn't save image, filename_format is invalid.");
+    return;
+  }
   if (cv::imwrite(filename, image))
   {
     NODELET_INFO("Saved image %s", filename.c_str());


### PR DESCRIPTION
From https://github.com/ros-perception/image_pipeline/pull/538

Currently, when the `filename_format` rosparam is invalid (e.g. format specifier is not included) and we try to save `image_view`'s image by right-click, `image_view` terminate with the error output like below:
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_
detail::error_info_injector<boost::io::too_many_args> >'
  what():  boost::too_many_args: format-string referred to fewer arguments than were passed
```
With this pull request, warn message is like below:
```
[ WARN] [1597853504.654056636]: Couldn't save image, filename_format is invalid.
```