### PR TITLE
Refactor stereo_image_proc tests

### DIFF
--- a/stereo_image_proc/test/test_disparity_node.py
+++ b/stereo_image_proc/test/test_disparity_node.py
@@ -104,9 +104,9 @@ class TestDisparityNode(unittest.TestCase):
             1
         )
 
-        # Wait up to 10 seconds to receive message
+        # Wait up to 60 seconds to receive message
         start_time = time.time()
-        while len(msgs_received) == 0 and (time.time() - start_time) < 10:
+        while len(msgs_received) == 0 and (time.time() - start_time) < 60:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         assert len(msgs_received) > 0

--- a/stereo_image_proc/test/test_disparity_node.py
+++ b/stereo_image_proc/test/test_disparity_node.py
@@ -41,6 +41,8 @@ from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
+import launch_testing
+
 import pytest
 
 import rclpy
@@ -49,7 +51,7 @@ from stereo_msgs.msg import DisparityImage
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
 
     path_to_stereo_image_publisher_fixture = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'stereo_image_publisher.py')
@@ -72,12 +74,11 @@ def generate_test_description(ready_fn):
         # DisparityNode
         Node(
             package='stereo_image_proc',
-            node_executable='disparity_node',
-            node_name='disparity_node',
+            executable='disparity_node',
+            name='disparity_node',
             output='screen'
         ),
-        # TODO(jacobperron): In Eloquent, use 'launch_testing.actions.ReadyToTest()'
-        OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest(),
     ])
 
 
@@ -94,7 +95,7 @@ class TestDisparityNode(unittest.TestCase):
         rclpy.shutdown()
 
     def test_message_received(self):
-        # Expect the disparity node to publish on '/diparity' topic
+        # Expect the disparity node to publish on '/disparity' topic
         msgs_received = []
         self.node.create_subscription(
             DisparityImage,

--- a/stereo_image_proc/test/test_disparity_node.py
+++ b/stereo_image_proc/test/test_disparity_node.py
@@ -36,8 +36,6 @@ import time
 import unittest
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
@@ -61,10 +59,9 @@ def generate_test_description():
 
     return LaunchDescription([
         # Stereo image publisher
-        # TODO(jacobperron): we can use Node in Eloquent
-        ExecuteProcess(
-            cmd=[
-                sys.executable,
+        Node(
+            executable=sys.executable,
+            arguments=[
                 path_to_stereo_image_publisher_fixture,
                 path_to_left_image,
                 path_to_right_image

--- a/stereo_image_proc/test/test_point_cloud_node.py
+++ b/stereo_image_proc/test/test_point_cloud_node.py
@@ -41,6 +41,8 @@ from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
+import launch_testing
+
 import pytest
 
 import rclpy
@@ -49,7 +51,7 @@ from sensor_msgs.msg import PointCloud2
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
 
     path_to_disparity_image_publisher_fixture = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'disparity_image_publisher.py')
@@ -72,12 +74,11 @@ def generate_test_description(ready_fn):
         # PointCloudNode
         Node(
             package='stereo_image_proc',
-            node_executable='point_cloud_node',
-            node_name='point_cloud_node',
+            executable='point_cloud_node',
+            name='point_cloud_node',
             output='screen'
         ),
-        # TODO(jacobperron): In Eloquent, use 'launch_testing.actions.ReadyToTest()'
-        OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest(),
     ])
 
 

--- a/stereo_image_proc/test/test_point_cloud_node.py
+++ b/stereo_image_proc/test/test_point_cloud_node.py
@@ -106,9 +106,9 @@ class TestPointCloudNode(unittest.TestCase):
             1
         )
 
-        # Wait up to 10 seconds to receive message
+        # Wait up to 60 seconds to receive message
         start_time = time.time()
-        while len(msgs_received) == 0 and (time.time() - start_time) < 10:
+        while len(msgs_received) == 0 and (time.time() - start_time) < 60:
             rclpy.spin_once(self.node, timeout_sec=(0.1))
 
         assert len(msgs_received) > 0

--- a/stereo_image_proc/test/test_point_cloud_node.py
+++ b/stereo_image_proc/test/test_point_cloud_node.py
@@ -36,8 +36,6 @@ import time
 import unittest
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
@@ -61,10 +59,9 @@ def generate_test_description():
 
     return LaunchDescription([
         # Disparity image publisher
-        # TODO(jacobperron): we can use Node in Eloquent
-        ExecuteProcess(
-            cmd=[
-                sys.executable,
+        Node(
+            executable=sys.executable,
+            arguments=[
                 path_to_disparity_image_publisher_fixture,
                 path_to_left_image,
                 path_to_disparity_image,
@@ -86,8 +83,6 @@ class TestPointCloudNode(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # TODO(jacobperron): Instead of handling the init/shutdown cycle, as of Eloqeunt
-        #                    we can use the node 'launch_service.context.locals.launch_ros_node'
         rclpy.init()
         cls.node = rclpy.create_node('test_point_cloud_node')
 


### PR DESCRIPTION
- Fixed some deprecation warnings (4543634)
- Increased test timeouts to 60 seconds (35dd2a7)
  - Locally, I've observed it can take up to 40 seconds to complete one of the tests when the host is under high stress. Hopefully, this will make the tests less flaky.
- Cleanup (c051070)