### PR TITLE
Update fisheye distortion model definition

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -295,7 +295,7 @@ def _get_dist_model(dist_params, cam_model):
         else:
             dist_model = "plumb_bob"
     elif CAMERA_MODEL.FISHEYE == cam_model:
-        dist_model = "fisheye"
+        dist_model = "equidistant"
     else:
         dist_model = "unknown"
     return dist_model


### PR DESCRIPTION
Update fisheye distortion model definition.
Replaces #581 retargeting to `noetic`

Update calibration tool distortion model for fisheye camera to be compatible with ros-perception/vision_opencv#306 and ros-perception/image_common#146 in as indicated in ros/common_msgs#151.