### PR TITLE
make crop_decimate work

### DIFF
--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -119,9 +119,9 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
   int interpolation = this->declare_parameter("interpolation", 0);
   interpolation_ = static_cast<CropDecimateModes>(interpolation);
 
-  pub_ = image_transport::create_camera_publisher(this, "image_raw");
+  pub_ = image_transport::create_camera_publisher(this, "out/image");
   sub_ = image_transport::create_camera_subscription(
-    this, "image_raw", std::bind(
+    this, "in/image", std::bind(
       &CropDecimateNode::imageCb, this,
       std::placeholders::_1, std::placeholders::_2), "raw");
 }

--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -119,9 +119,9 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
   int interpolation = this->declare_parameter("interpolation", 0);
   interpolation_ = static_cast<CropDecimateModes>(interpolation);
 
-  pub_ = image_transport::create_camera_publisher(this, "out/image");
+  pub_ = image_transport::create_camera_publisher(this, "out/image_raw");
   sub_ = image_transport::create_camera_subscription(
-    this, "in/image", std::bind(
+    this, "in/image_raw", std::bind(
       &CropDecimateNode::imageCb, this,
       std::placeholders::_1, std::placeholders::_2), "raw");
 }


### PR DESCRIPTION
in ROS1, there were two different nodehandles,
which put these in different namespaces. Right
now this publishes the same topic it subscribes
to. The style of naming also allows the
camera_info topics to be properly remapped