### PR TITLE
Fixed crash when rosargs are given

### DIFF
--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -84,7 +84,7 @@ def main():
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     parser.add_option_group(group)
-    options, args = parser.parse_args()
+    options, _ = parser.parse_args(rclpy.utilities.remove_ros_args())
 
     if len(options.size) != len(options.square):
         parser.error("Number of size and square inputs must be the same!")
@@ -140,7 +140,7 @@ def main():
     else:
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
 
-    rclpy.init(args=args)
+    rclpy.init()
     node = OpenCVCalibrationNode("cameracalibrator", boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags)
     node.spin()

--- a/camera_calibration/src/camera_calibration/nodes/cameracheck.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracheck.py
@@ -45,8 +45,8 @@ def main():
                       type="float", default=0.0,
                       help="allow specified slop (in seconds) when pairing images from unsynchronized stereo cameras")
 
-    options, args = parser.parse_args()
-    rclpy.init(args=args)
+    options, _ = parser.parse_args(rclpy.utilities.remove_ros_args())
+    rclpy.init()
 
     size = tuple([int(c) for c in options.size.split('x')])
     dim = float(options.square)


### PR DESCRIPTION
This PR fixes `cameracalibrator` and `cameracheck` from crashing when `--ros-args` are supplied on ROS2 Foxy.

Bug is triggered when running for example:

`/opt/ros/foxy/lib/camera_calibration/cameracalibrator --approximate=0.01 --pattern=acircles --size=4x11 --square=0.0571 --no-service-check --ros-args -r /right:=/camera/right/image_rect -r /left:=/camera/left/image_rect -r /left_camera/set_camera_info:=/camera/left/set_camera_info -r /right_camera/set_camera_info:=/camera/right/set_camera_info`

Crash with:
`cameracalibrator: error: no such option: --ros-args`

The ros arguments are needed to do remappings.