### PR TITLE
[video_recorder] Add timer to record low fps video at the correct speed

### DIFF
--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -40,7 +40,6 @@ double max_depth_range;
 bool use_dynamic_range;
 int colormap;
 cv::Mat image;
-ros::Time stamp;
 
 
 void callback(const sensor_msgs::ImageConstPtr& image_msg)
@@ -72,8 +71,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg)
 
     }
 
-    stamp = image_msg->header.stamp;
-    if ((stamp - g_last_wrote_time) < ros::Duration(1.0 / fps))
+    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1.0 / fps))
     {
       // Skip to get video with correct fps
       return;
@@ -100,7 +98,7 @@ void timercallback(const ros::TimerEvent&)
       outputVideo << image;
       ROS_INFO_STREAM("Recording frame " << g_count << "\x1b[1F");
       g_count++;
-      g_last_wrote_time = stamp;
+      g_last_wrote_time = ros::Time::now();
     } else {
       ROS_WARN("Frame skipped, no data!");
     }

--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -49,7 +49,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg)
 
         cv::Size size(image_msg->width, image_msg->height);
 
-        outputVideo.open(filename,
+        outputVideo.open(filename, 
 #if CV_MAJOR_VERSION >= 3
                 cv::VideoWriter::fourcc(codec.c_str()[0],
 #else
@@ -57,7 +57,7 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg)
 #endif
                           codec.c_str()[1],
                           codec.c_str()[2],
-                          codec.c_str()[3]),
+                          codec.c_str()[3]), 
                 fps,
                 size,
                 true);


### PR DESCRIPTION
Without this pull request, when we record video with lower fps than `fps` rosparam, the output video will be fast and shortened.

For example, if we set `fps` rosparam as 15 but input `sensor_msgs::Image` topic's hz is 5 and we record video for 30 seconds, the output video is only 10 seconds and 3x speed.

This pull request solves the above problem by using timer callback and outputting video at regular intervals.