### PR TITLE
Added frame-skipping tolerance parameter

### DIFF
--- a/image_view/src/nodes/video_recorder.cpp
+++ b/image_view/src/nodes/video_recorder.cpp
@@ -34,6 +34,7 @@ ros::Time g_last_wrote_time = ros::Time(0);
 std::string encoding;
 std::string codec;
 int fps;
+double tolerance;
 std::string filename;
 double min_depth_range;
 double max_depth_range;
@@ -70,9 +71,14 @@ void callback(const sensor_msgs::ImageConstPtr& image_msg)
 
     }
 
-    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1.0 / fps))
+    if ((image_msg->header.stamp - g_last_wrote_time) < ros::Duration((1.0 / fps)*(1.0-tolerance/100)))
     {
       // Skip to get video with correct fps
+      ROS_INFO_STREAM("Skipping frame "<< g_count <<": "
+                << image_msg->header.stamp - g_last_wrote_time << " sec is outside of the " 
+                << tolerance<< "\% tolerance");
+      
+      g_count++;
       return;
     }
 
@@ -108,6 +114,7 @@ int main(int argc, char** argv)
     bool stamped_filename;
     local_nh.param("stamped_filename", stamped_filename, false);
     local_nh.param("fps", fps, 15);
+    local_nh.param("tolerance", tolerance, 15.0);
     local_nh.param("codec", codec, std::string("MJPG"));
     local_nh.param("encoding", encoding, std::string("bgr8"));
     // cv_bridge::CvtColorForDisplayOptions


### PR DESCRIPTION
### Package/Feature:
**image_view**,  _video_recorder_ 

### Description:
Added a tolerance parameter for frame-skipping that enables the user to choose how much variation in framerate is acceptable.

### What this fixes:
This is a fix for Issue #604. Adding a frame-skipping tolerance allows us to change the condition for frame skipping to allow for some natural variation (which often occurs when streaming video from a webcam using [usb_cam](http://wiki.ros.org/usb_cam) for example).

### Details:
The tolerance parameter is a percent, and is passed to the _video_recorder_ node via the parameter server:
```xml
<node name="video_recorder_node" pkg="image_view" type="video_recorder" respawn="false" output="screen">
    <remap from="image" to="/usb_cam/image_raw"/>
    <param name="fps" value="30" />
    <param name="tolerance" value="15" />
    <param name="codec" value="avc1" />
    <param name="filename" value="output.mp4" />
</node>
```

The condition in _video_recorder_ for frame skipping changes from:
```cpp
if ( (image_msg->header.stamp - g_last_wrote_time) < ros::Duration(1.0 / fps) )
```
to 
```cpp
if ( (image_msg->header.stamp - g_last_wrote_time) < ros::Duration( (1.0 / fps)*(1.0-tolerance/100) ) )
```
This allows some amount of variation in the framerate to be acceptable.

### Testing
**Platform:** Ubuntu 20.04, ROS Noetic
**Hardware:** Logitech C920 Webcam

1. Start a camera stream using [usb_cam](http://wiki.ros.org/usb_cam), with 30fps using the mjpeg format to get the direct compressed stream from this camera.
2. Start a video_recorder with 30 fps, 15% tolerance, and the avc1 codec (for H.264 compression)
3. No frames are dropped!
4. Repeat this with 0% tolerance: approximately every 5th frame dropped, so video is 20% shorter than it should be, and plays back too fast.

I think this confirms that the addition of the frame-skip tolerance has fixed the problem.
