### PR TITLE
Make HAVE_GTK depend on finding gtk

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -6,10 +6,12 @@ generate_dynamic_reconfigure_options(cfg/ImageView.cfg)
 
 catkin_package(CATKIN_DEPENDS dynamic_reconfigure)
 find_package(Boost REQUIRED COMPONENTS thread)
+find_package(GTK2 REQUIRED)
 find_package(OpenCV REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
+                    ${GTK2_INCLUDE_DIRS}
                     ${OpenCV_INCLUDE_DIRS}
 )
 
@@ -37,12 +39,6 @@ install(TARGETS extract_images image_saver video_recorder
 if(ANDROID)
   return()
 endif()
-
-find_package(GTK2)
-if(GTK2_FOUND)
-add_definitions(-DHAVE_GTK)
-include_directories(${GTK2_INCLUDE_DIRS})
-endif(GTK2_FOUND)
 
 # Nodelet library
 add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nodelet.cpp src/nodelets/window_thread.cpp)

--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -39,8 +39,10 @@ if(ANDROID)
 endif()
 
 find_package(GTK2)
+if(GTK2_FOUND)
 add_definitions(-DHAVE_GTK)
 include_directories(${GTK2_INCLUDE_DIRS})
+endif(GTK2_FOUND)
 
 # Nodelet library
 add_library(image_view src/nodelets/image_nodelet.cpp src/nodelets/disparity_nodelet.cpp src/nodelets/window_thread.cpp)

--- a/image_view/src/nodelets/disparity_nodelet.cpp
+++ b/image_view/src/nodelets/disparity_nodelet.cpp
@@ -38,7 +38,6 @@
 #include <opencv2/highgui/highgui.hpp>
 #include "window_thread.h"
 
-#ifdef HAVE_GTK
 #include <gtk/gtk.h>
 
 // Platform-specific workaround for #3026: image_view doesn't close when
@@ -55,7 +54,6 @@ static void destroyNodelet(GtkWidget *widget, gpointer data)
   // unsubscribe from the image topic.
   reinterpret_cast<ros::Subscriber*>(data)->shutdown();
 }
-#endif
 
 
 namespace image_view {
@@ -103,14 +101,12 @@ void DisparityNodelet::onInit()
 
   //cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
 #if CV_MAJOR_VERSION ==2
-#ifdef HAVE_GTK
   // Register appropriate handler for when user closes the display window
   GtkWidget *widget = GTK_WIDGET( cvGetWindowHandle(window_name_.c_str()) );
   if (shutdown_on_close)
     g_signal_connect(widget, "destroy", G_CALLBACK(destroyNode), NULL);
   else
     g_signal_connect(widget, "destroy", G_CALLBACK(destroyNodelet), &sub_);
-#endif
   // Start the OpenCV window thread so we don't have to waitKey() somewhere
   startWindowThread();
 #endif

--- a/image_view/src/nodes/stereo_view.cpp
+++ b/image_view/src/nodes/stereo_view.cpp
@@ -49,7 +49,6 @@
 #include <boost/thread.hpp>
 #include <boost/format.hpp>
 
-#ifdef HAVE_GTK
 #include <gtk/gtk.h>
 
 // Platform-specific workaround for #3026: image_view doesn't close when
@@ -59,7 +58,6 @@ static void destroy(GtkWidget *widget, gpointer data)
 {
   ros::shutdown();
 }
-#endif
 
 namespace enc = sensor_msgs::image_encodings;
 
@@ -380,14 +378,12 @@ public:
     cv::setMouseCallback("right",     &StereoView::mouseCb, this);
     cv::setMouseCallback("disparity", &StereoView::mouseCb, this);
 #if CV_MAJOR_VERSION == 2
-#ifdef HAVE_GTK
     g_signal_connect(GTK_WIDGET( cvGetWindowHandle("left") ),
                      "destroy", G_CALLBACK(destroy), NULL);
     g_signal_connect(GTK_WIDGET( cvGetWindowHandle("right") ),
                      "destroy", G_CALLBACK(destroy), NULL);
     g_signal_connect(GTK_WIDGET( cvGetWindowHandle("disparity") ),
                      "destroy", G_CALLBACK(destroy), NULL);
-#endif
     cvStartWindowThread();
 #endif
 


### PR DESCRIPTION
It looks like gtk was removed entirely then restored a few years ago https://github.com/ros-perception/image_pipeline/commit/0faa2e14cbd6b26bbc884ac051e7e77948807a14 .

If gtk isn't actually optional, then the change should be to add a `required` to the `find_package(GTK2)`.