### PR TITLE
Fix shebang lines for noetic python3

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Software License Agreement (BSD License)
 #

--- a/camera_calibration/nodes/cameracheck.py
+++ b/camera_calibration/nodes/cameracheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Software License Agreement (BSD License)
 #

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Software License Agreement (BSD License)
 #

--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Software License Agreement (BSD License)
 #


### PR DESCRIPTION
The shebang lines were not corrected as part of the `noetic`/`focal` release.

This updates the shebangs to follow the guidance here: https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

This caused execution errors as found in an [answers post](https://answers.ros.org/question/363942/camera_calibration-does-not-work-ros-noetic/)

Signed-off-by: Michael Carroll <michael@openrobotics.org>