### PR TITLE
Warning instead of Error when frames are differents

### DIFF
--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -150,10 +150,9 @@ void PointCloudXyziNode::imageCb(
 {
   // Check for bad inputs
   if (depth_msg->header.frame_id != intensity_msg_in->header.frame_id) {
-    RCLCPP_ERROR(
+    RCLCPP_WARN(
       logger_, "Depth image frame id [%s] doesn't match image frame id [%s]",
       depth_msg->header.frame_id.c_str(), intensity_msg_in->header.frame_id.c_str());
-    return;
   }
 
   // Update camera model

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -150,8 +150,11 @@ void PointCloudXyziNode::imageCb(
 {
   // Check for bad inputs
   if (depth_msg->header.frame_id != intensity_msg_in->header.frame_id) {
-    RCLCPP_WARN(
-      logger_, "Depth image frame id [%s] doesn't match image frame id [%s]",
+    RCLCPP_WARN_THROTTLE(
+      logger_,
+      *get_clock(),
+      10000,  // 10 seconds
+      "Depth image frame id [%s] doesn't match image frame id [%s]",
       depth_msg->header.frame_id.c_str(), intensity_msg_in->header.frame_id.c_str());
   }
 

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -166,8 +166,11 @@ void PointCloudXyzrgbNode::imageCb(
 {
   // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
-    RCLCPP_WARN(
-      logger_, "Depth image frame id [%s] doesn't match RGB image frame id [%s]",
+    RCLCPP_WARN_THROTTLE(
+      logger_,
+      *get_clock(),
+      10000,  // 10 seconds
+      "Depth image frame id [%s] doesn't match RGB image frame id [%s]",
       depth_msg->header.frame_id.c_str(), rgb_msg_in->header.frame_id.c_str());
   }
 

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -164,12 +164,11 @@ void PointCloudXyzrgbNode::imageCb(
   const Image::ConstSharedPtr & rgb_msg_in,
   const CameraInfo::ConstSharedPtr & info_msg)
 {
-  // Check for bad inputs
+  Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
-    RCLCPP_ERROR(
+    RCLCPP_WARN(
       logger_, "Depth image frame id [%s] doesn't match RGB image frame id [%s]",
       depth_msg->header.frame_id.c_str(), rgb_msg_in->header.frame_id.c_str());
-    return;
   }
 
   // Update camera model

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -164,7 +164,7 @@ void PointCloudXyzrgbNode::imageCb(
   const Image::ConstSharedPtr & rgb_msg_in,
   const CameraInfo::ConstSharedPtr & info_msg)
 {
-  Check for bad inputs
+  // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
     RCLCPP_WARN(
       logger_, "Depth image frame id [%s] doesn't match RGB image frame id [%s]",


### PR DESCRIPTION
Hi all,

Sometimes the depth and RGB images are not produced by the same device, or the frames set by the driver are not the same. For example, the webots simulator and Orbbec Astra Driver (#628) use different devices for each one, with different frame id. 

This PR proposes to manage this situation as a warning, instead of an error, and continuing the processing.

I hope it will be considered :)
Francisco