### PR TITLE
Support MONO16 image encodings.

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyz.cpp
@@ -114,7 +114,7 @@ void PointCloudXyzNodelet::depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
   // Update camera model
   model_.fromCameraInfo(info_msg);
 
-  if (depth_msg->encoding == enc::TYPE_16UC1)
+  if (depth_msg->encoding == enc::TYPE_16UC1 || depth_msg->encoding == enc::MONO16)
   {
     convert<uint16_t>(depth_msg, cloud_msg, model_);
   }


### PR DESCRIPTION
Needed for working with RealSense depth images, which are MONO16.