### PR TITLE
Add missing cstdint, vector, cmath includes.

### DIFF
--- a/depth_image_proc/include/depth_image_proc/depth_traits.h
+++ b/depth_image_proc/include/depth_image_proc/depth_traits.h
@@ -35,7 +35,10 @@
 #define DEPTH_IMAGE_PROC_DEPTH_TRAITS
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <limits>
+#include <vector>
 
 namespace depth_image_proc {
 


### PR DESCRIPTION
All of these were missing for a case where we were pulling in this header.