### PR TITLE
Provide the option to use reliable subscribers

### DIFF
--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -55,6 +55,7 @@ def generate_launch_description():
             parameters=[{
                 'approximate_sync': LaunchConfiguration('approximate_sync'),
                 'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
+                'use_reliable_subscribers': LaunchConfiguration('use_reliable_subscribers'),
                 'stereo_algorithm': LaunchConfiguration('stereo_algorithm'),
                 'prefilter_size': LaunchConfiguration('prefilter_size'),
                 'prefilter_cap': LaunchConfiguration('prefilter_cap'),
@@ -84,6 +85,7 @@ def generate_launch_description():
                 'approximate_sync': LaunchConfiguration('approximate_sync'),
                 'avoid_point_cloud_padding': LaunchConfiguration('avoid_point_cloud_padding'),
                 'use_system_default_qos': LaunchConfiguration('use_system_default_qos'),
+                'use_reliable_subscribers': LaunchConfiguration('use_reliable_subscribers'),
             }],
             remappings=[
                 ('left/camera_info', [LaunchConfiguration('left_namespace'), '/camera_info']),
@@ -112,6 +114,10 @@ def generate_launch_description():
         DeclareLaunchArgument(
             name='use_system_default_qos', default_value='False',
             description='Use the RMW QoS settings for the image and camera info subscriptions.'
+        ),
+        DeclareLaunchArgument(
+            name='use_reliable_subscribers', default_value='False',
+            description='Use reliable QoS for the disparity and point cloud subscriptions.'
         ),
         DeclareLaunchArgument(
             name='launch_image_proc', default_value='True',

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -157,6 +157,7 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
   this->declare_parameter("use_system_default_qos", false);
+  this->declare_parameter("use_reliable_subscribers", false);
 
   // Synchronize callbacks
   if (approx) {
@@ -281,6 +282,10 @@ void DisparityNode::connectCb()
   rclcpp::QoS image_sub_qos = rclcpp::SensorDataQoS();
   if (use_system_default_qos) {
     image_sub_qos = rclcpp::SystemDefaultsQoS();
+  }
+  const bool use_reliable_subscribers = this->get_parameter("use_reliable_subscribers").as_bool();
+  if (use_reliable_subscribers) {
+    image_sub_qos.reliable();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
   sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos);

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -101,6 +101,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
   this->declare_parameter("use_system_default_qos", false);
+  this->declare_parameter("use_reliable_subscribers", false);
   rcl_interfaces::msg::ParameterDescriptor descriptor;
   // TODO(ivanpauno): Confirm if using point cloud padding in `sensor_msgs::msg::PointCloud2`
   // can improve performance in some cases or not.
@@ -145,6 +146,10 @@ void PointCloudNode::connectCb()
   rclcpp::QoS image_sub_qos = rclcpp::SensorDataQoS();
   if (use_system_default_qos) {
     image_sub_qos = rclcpp::SystemDefaultsQoS();
+  }
+  const bool use_reliable_subscribers = this->get_parameter("use_reliable_subscribers").as_bool();
+  if (use_reliable_subscribers) {
+    image_sub_qos.reliable();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
   sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos);

--- a/stereo_image_proc/test/test_disparity_node.py
+++ b/stereo_image_proc/test/test_disparity_node.py
@@ -73,7 +73,9 @@ def generate_test_description():
             package='stereo_image_proc',
             executable='disparity_node',
             name='disparity_node',
-            output='screen'
+            output='screen',
+            parameters=[{'use_reliable_subscribers': True}]
+
         ),
         launch_testing.actions.ReadyToTest(),
     ])

--- a/stereo_image_proc/test/test_point_cloud_node.py
+++ b/stereo_image_proc/test/test_point_cloud_node.py
@@ -73,7 +73,8 @@ def generate_test_description():
             package='stereo_image_proc',
             executable='point_cloud_node',
             name='point_cloud_node',
-            output='screen'
+            output='screen',
+            parameters=[{'use_reliable_subscribers': True}]
         ),
         launch_testing.actions.ReadyToTest(),
     ])


### PR DESCRIPTION
Allow a calling launch script to configure the use of reliable subscribers for the disparity and point cloud nodes.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>