### PR TITLE
Add retry feature on the image publisher node when no stream is available or if the the stream dropsout

### DIFF
--- a/image_publisher/include/image_publisher/image_publisher.hpp
+++ b/image_publisher/include/image_publisher/image_publisher.hpp
@@ -64,6 +64,8 @@ private:
   std::string filename_;
   bool flip_horizontal_;
   bool flip_vertical_;
+  bool retry_;  // If enabled will retry loading image from the filename_
+  int timeout_;  // Time after which retrying starts
 
   std::string frame_id_;
   double publish_rate_;


### PR DESCRIPTION
#### Aim

At times it could happen that the video stream is:
  1. Not ready at the beginning
  2. Drops out for a short duration 

In these cases, the image publisher node throws an error and is not able to recover if the stream gets ready or recovers. The idea is to retry creating the video capture if this happens.

#### Parameters

1. retry (bool) - If enabled, will retry the `onInit()` method.
2. timeout (int) - Time after which retrying starts 