### PR TITLE
Fix deprecation warning calling declare_parameter

### DIFF
--- a/depth_image_proc/src/crop_foremost.cpp
+++ b/depth_image_proc/src/crop_foremost.cpp
@@ -66,8 +66,7 @@ private:
 CropForemostNode::CropForemostNode(const rclcpp::NodeOptions & options)
 : Node("CropForemostNode", options)
 {
-  this->declare_parameter("distance");
-  this->get_parameter("distance", distance_);
+  distance_ = this->declare_parameter("distance", 0.0);
 
   // Monitor whether anyone is subscribed to the output
   // TODO(ros2) Implement when SubscriberStatusCallback is available


### PR DESCRIPTION
As of https://github.com/ros2/rclcpp/pull/1522 (upcoming in Galactic), we must also declare the type of the parameter.
We can do this implicitly by providing a default value.

Prior to this change, distance_ was being default-initialized to 0.0 anyways.

