### PR TITLE
Fix build with later versions of OpenCV 3

### DIFF
--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -46,10 +46,9 @@ void debayer2x2toBGR(
   int R, int G1, int G2, int B)
 {
   typedef cv::Vec<T, 3> DstPixel;  // 8- or 16-bit BGR
-#if CV_VERSION_MAJOR >= 4
+#if CV_VERSION_MAJOR >= 4 || (CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION > 2)
   dst.create(src.rows / 2, src.cols / 2, cv::traits::Type<DstPixel>::value);
 #else
-  // Assume OpenCV 3 API
   dst.create(src.rows / 2, src.cols / 2, cv::DataType<DstPixel>::type);
 #endif
 


### PR DESCRIPTION
This first regressed in #534. Support for OpenCV 3.2 was re-added in #564. This fixes the build with OpenCV 3.3 and newer.

Original change was here: https://github.com/ros-perception/image_pipeline/commit/bb4c2db562686bb9939f748e3ffb3f55a9fbb35d#diff-2478c8be1a7ff3c6e582de5e1e738cc05c22dd7fcbdb3599a1999ab849045517

RHEL 8 uses OpenCV 3.4.6.