### PR TITLE
Add QoS overrides to stereo_image_proc

### DIFF
--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -267,17 +267,7 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
 
   // Update the publisher options to allow reconfigurable qos settings.
   rclcpp::PublisherOptions pub_opts;
-  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
-    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
-    rclcpp::QosPolicyKind::Deadline,
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Lifespan,
-    rclcpp::QosPolicyKind::Liveliness,
-    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
-    rclcpp::QosPolicyKind::Reliability,
-  }};
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
@@ -297,17 +287,7 @@ void DisparityNode::connectCb()
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
   auto sub_opts = rclcpp::SubscriptionOptions();
-  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
-    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
-    rclcpp::QosPolicyKind::Deadline,
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Lifespan,
-    rclcpp::QosPolicyKind::Liveliness,
-    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
-    rclcpp::QosPolicyKind::Reliability,
-  }};
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   sub_l_image_.subscribe(
     this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -277,7 +277,6 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
     rclcpp::QosPolicyKind::Liveliness,
     rclcpp::QosPolicyKind::LivelinessLeaseDuration,
     rclcpp::QosPolicyKind::Reliability,
-    rclcpp::QosPolicyKind::Invalid,
   }};
   pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1, pub_opts);
 

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -296,7 +296,7 @@ void DisparityNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+  auto sub_opts = rclcpp::SubscriptionOptions();
   sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
     rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
     rclcpp::QosPolicyKind::Deadline,
@@ -308,9 +308,13 @@ void DisparityNode::connectCb()
     rclcpp::QosPolicyKind::LivelinessLeaseDuration,
     rclcpp::QosPolicyKind::Reliability,
   }};
-  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_image_.subscribe(
+    this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos,
+    sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
-  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_r_image_.subscribe(
+    this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos,
+    sub_opts);
   sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
 }
 

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -296,10 +296,22 @@ void DisparityNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos);
-  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
-  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos);
-  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
+  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
+    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
+    rclcpp::QosPolicyKind::Deadline,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Lifespan,
+    rclcpp::QosPolicyKind::Liveliness,
+    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+    rclcpp::QosPolicyKind::Reliability,
+  }};
+  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
 }
 
 void DisparityNode::imageCb(

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -309,12 +309,10 @@ void DisparityNode::connectCb()
     rclcpp::QosPolicyKind::Reliability,
   }};
   sub_l_image_.subscribe(
-    this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos,
-    sub_opts);
+    this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
   sub_r_image_.subscribe(
-    this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos,
-    sub_opts);
+    this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
 }
 

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -265,7 +265,21 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   this->declare_parameters("", double_params);
   this->declare_parameters("", bool_params);
 
-  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1);
+  // Update the publisher options to allow reconfigurable qos settings.
+  rclcpp::PublisherOptions pub_opts;
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
+    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
+    rclcpp::QosPolicyKind::Deadline,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Lifespan,
+    rclcpp::QosPolicyKind::Liveliness,
+    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+    rclcpp::QosPolicyKind::Reliability,
+    rclcpp::QosPolicyKind::Invalid,
+  }};
+  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -132,17 +132,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
 
   // Update the publisher options to allow reconfigurable qos settings.
   rclcpp::PublisherOptions pub_opts;
-  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
-    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
-    rclcpp::QosPolicyKind::Deadline,
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Lifespan,
-    rclcpp::QosPolicyKind::Liveliness,
-    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
-    rclcpp::QosPolicyKind::Reliability,
-  }};
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
@@ -162,17 +152,7 @@ void PointCloudNode::connectCb()
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
   auto sub_opts = rclcpp::SubscriptionOptions();
-  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
-    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
-    rclcpp::QosPolicyKind::Deadline,
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Lifespan,
-    rclcpp::QosPolicyKind::Liveliness,
-    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
-    rclcpp::QosPolicyKind::Reliability,
-  }};
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   sub_l_image_.subscribe(
     this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -142,7 +142,6 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
     rclcpp::QosPolicyKind::Liveliness,
     rclcpp::QosPolicyKind::LivelinessLeaseDuration,
     rclcpp::QosPolicyKind::Reliability,
-    rclcpp::QosPolicyKind::Invalid,
   }};
   pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1, pub_opts);
 

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -174,8 +174,7 @@ void PointCloudNode::connectCb()
     rclcpp::QosPolicyKind::Reliability,
   }};
   sub_l_image_.subscribe(
-    this, "left/image_rect_color",
-    hints.getTransport(), image_sub_rmw_qos, sub_opts);
+    this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
   sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
   sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos, sub_opts);

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -161,10 +161,22 @@ void PointCloudNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos);
-  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
-  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
-  sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos);
+  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
+    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
+    rclcpp::QosPolicyKind::Deadline,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Lifespan,
+    rclcpp::QosPolicyKind::Liveliness,
+    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+    rclcpp::QosPolicyKind::Reliability,
+  }};
+  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos, sub_opts);
 }
 
 inline bool isValidPoint(const cv::Vec3f & pt)

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -130,7 +130,21 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
       std::bind(&PointCloudNode::imageCb, this, _1, _2, _3, _4));
   }
 
-  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1);
+  // Update the publisher options to allow reconfigurable qos settings.
+  rclcpp::PublisherOptions pub_opts;
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
+    rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
+    rclcpp::QosPolicyKind::Deadline,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Lifespan,
+    rclcpp::QosPolicyKind::Liveliness,
+    rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+    rclcpp::QosPolicyKind::Reliability,
+    rclcpp::QosPolicyKind::Invalid,
+  }};
+  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -161,7 +161,7 @@ void PointCloudNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+  auto sub_opts = rclcpp::SubscriptionOptions();
   sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions {{
     rclcpp::QosPolicyKind::AvoidRosNamespaceConventions,
     rclcpp::QosPolicyKind::Deadline,
@@ -173,7 +173,9 @@ void PointCloudNode::connectCb()
     rclcpp::QosPolicyKind::LivelinessLeaseDuration,
     rclcpp::QosPolicyKind::Reliability,
   }};
-  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_image_.subscribe(
+    this, "left/image_rect_color",
+    hints.getTransport(), image_sub_rmw_qos, sub_opts);
   sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
   sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
   sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos, sub_opts);


### PR DESCRIPTION
This is adding QoS overrides, which were added in https://github.com/ros2/rclcpp/pull/1408.

This PR relies on
* [x] https://github.com/ros-perception/image_common/pull/186
* [x] https://github.com/ros2/message_filters/pull/56