### PR TITLE
[depth_image_proc] move to hpp/cpp structure, create conversions file

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 find_package(OpenCV REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/conversions.cpp
   src/convert_metric.cpp
   src/crop_foremost.cpp
   src/disparity.cpp

--- a/depth_image_proc/include/depth_image_proc/conversions.hpp
+++ b/depth_image_proc/include/depth_image_proc/conversions.hpp
@@ -29,10 +29,10 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#ifndef DEPTH_IMAGE_PROC__DEPTH_CONVERSIONS_HPP_
-#define DEPTH_IMAGE_PROC__DEPTH_CONVERSIONS_HPP_
+#ifndef DEPTH_IMAGE_PROC__CONVERSIONS_HPP_
+#define DEPTH_IMAGE_PROC__CONVERSIONS_HPP_
 
-#include <sensor_msgs/msg/image.h>
+#include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>
@@ -42,53 +42,35 @@
 namespace depth_image_proc
 {
 
-using PointCloud = sensor_msgs::msg::PointCloud2;
+// Handles float or uint16 depths
+template<typename T>
+void convertDepth(
+  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  const image_geometry::PinholeCameraModel & model,
+  double range_max = 0.0);
 
 // Handles float or uint16 depths
 template<typename T>
-void convert(
+void convertDepthRadial(
   const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  PointCloud::SharedPtr & cloud_msg,
-  const image_geometry::PinholeCameraModel & model,
-  double range_max = 0.0)
-{
-  // Use correct principal point from calibration
-  float center_x = model.cx();
-  float center_y = model.cy();
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  cv::Mat & transform);
 
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
-  float constant_x = unit_scaling / model.fx();
-  float constant_y = unit_scaling / model.fy();
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
+// Handles float or uint16 depths
+template<typename T>
+void convertIntensity(
+  const sensor_msgs::msg::Image::ConstSharedPtr & intensity_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg);
 
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
-      T depth = depth_row[u];
+// Handles RGB8, BGR8, and MONO8
+void convertRgb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  int red_offset, int green_offset, int blue_offset, int color_step);
 
-      // Missing points denoted by NaNs
-      if (!DepthTraits<T>::valid(depth)) {
-        if (range_max != 0.0) {
-          depth = DepthTraits<T>::fromMeters(range_max);
-        } else {
-          *iter_x = *iter_y = *iter_z = bad_point;
-          continue;
-        }
-      }
-
-      // Fill in XYZ
-      *iter_x = (u - center_x) * depth * constant_x;
-      *iter_y = (v - center_y) * depth * constant_y;
-      *iter_z = DepthTraits<T>::toMeters(depth);
-    }
-  }
-}
+cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int height, bool radial);
 
 }  // namespace depth_image_proc
 
-#endif  // DEPTH_IMAGE_PROC__DEPTH_CONVERSIONS_HPP_
+#endif  // DEPTH_IMAGE_PROC__CONVERSIONS_HPP_

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <image_geometry/pinhole_camera_model.h>
+#include <depth_image_proc/conversions.hpp>
+#include <depth_image_proc/visibility.h>
+
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <memory>
+
+namespace depth_image_proc
+{
+
+namespace enc = sensor_msgs::image_encodings;
+
+class PointCloudXyzNode : public rclcpp::Node
+{
+public:
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzNode(const rclcpp::NodeOptions & options);
+
+private:
+  using PointCloud2 = sensor_msgs::msg::PointCloud2;
+  using Image = sensor_msgs::msg::Image;
+  using CameraInfo = sensor_msgs::msg::CameraInfo;
+
+  // Subscriptions
+  image_transport::CameraSubscriber sub_depth_;
+  int queue_size_;
+
+  // Publications
+  std::mutex connect_mutex_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;
+
+  image_geometry::PinholeCameraModel model_;
+
+  void connectCb();
+
+  void depthCb(
+    const Image::ConstSharedPtr & depth_msg,
+    const CameraInfo::ConstSharedPtr & info_msg);
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzNode");
+};
+
+}  // namespace depth_image_proc
+
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_HPP_

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyz_radial.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyz_radial.hpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_RADIAL_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_RADIAL_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <image_geometry/pinhole_camera_model.h>
+#include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/conversions.hpp>
+#include <depth_image_proc/visibility.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <memory>
+#include <vector>
+#include <limits>
+
+namespace depth_image_proc
+{
+
+namespace enc = sensor_msgs::image_encodings;
+
+class PointCloudXyzRadialNode : public rclcpp::Node
+{
+public:
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzRadialNode(const rclcpp::NodeOptions & options);
+
+private:
+  // Subscriptions
+  image_transport::CameraSubscriber sub_depth_;
+  int queue_size_;
+
+  // Publications
+  std::mutex connect_mutex_;
+  using PointCloud = sensor_msgs::msg::PointCloud2;
+  rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;
+
+  std::vector<double> D_;
+  std::array<double, 9> K_;
+
+  uint32_t width_;
+  uint32_t height_;
+
+  cv::Mat transform_;
+
+  void connectCb();
+
+  void depthCb(
+    const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzRadialNode");
+};
+
+}  // namespace depth_image_proc
+
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_RADIAL_HPP_

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <image_geometry/pinhole_camera_model.h>
+#include <depth_image_proc/conversions.hpp>
+#include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/visibility.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <memory>
+#include <string>
+#include <limits>
+
+namespace depth_image_proc
+{
+
+namespace enc = sensor_msgs::image_encodings;
+
+class PointCloudXyziNode : public rclcpp::Node
+{
+public:
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyziNode(const rclcpp::NodeOptions & options);
+
+private:
+  using Image = sensor_msgs::msg::Image;
+  using CameraInfo = sensor_msgs::msg::CameraInfo;
+  using PointCloud = sensor_msgs::msg::PointCloud2;
+
+  // Subscriptions
+  image_transport::SubscriberFilter sub_depth_, sub_intensity_;
+  message_filters::Subscriber<CameraInfo> sub_info_;
+  using SyncPolicy =
+    message_filters::sync_policies::ApproximateTime<Image, Image, CameraInfo>;
+  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+  std::shared_ptr<Synchronizer> sync_;
+
+  // Publications
+  std::mutex connect_mutex_;
+  rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;
+
+  image_geometry::PinholeCameraModel model_;
+
+  void connectCb();
+
+  void imageCb(
+    const Image::ConstSharedPtr & depth_msg,
+    const Image::ConstSharedPtr & intensity_msg,
+    const CameraInfo::ConstSharedPtr & info_msg);
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyziNode");
+};
+
+}  // namespace depth_image_proc
+
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_HPP_

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzi_radial.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzi_radial.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_RADIAL_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_RADIAL_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/exact_time.h>
+#include <image_geometry/pinhole_camera_model.h>
+#include <depth_image_proc/conversions.hpp>
+#include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/visibility.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <memory>
+#include <vector>
+#include <string>
+#include <limits>
+
+namespace depth_image_proc
+{
+
+namespace enc = sensor_msgs::image_encodings;
+using SyncPolicy =
+  message_filters::sync_policies::ExactTime<
+  sensor_msgs::msg::Image,
+  sensor_msgs::msg::Image,
+  sensor_msgs::msg::CameraInfo>;
+
+class PointCloudXyziRadialNode : public rclcpp::Node
+{
+public:
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyziRadialNode(const rclcpp::NodeOptions & options);
+
+private:
+  using PointCloud = sensor_msgs::msg::PointCloud2;
+  using Image = sensor_msgs::msg::Image;
+  using CameraInfo = sensor_msgs::msg::CameraInfo;
+
+  // Subscriptions
+  image_transport::SubscriberFilter sub_depth_, sub_intensity_;
+  message_filters::Subscriber<sensor_msgs::msg::CameraInfo> sub_info_;
+
+  int queue_size_;
+
+  // Publications
+  std::mutex connect_mutex_;
+  rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;
+
+  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+  std::shared_ptr<Synchronizer> sync_;
+
+  std::vector<double> D_;
+  std::array<double, 9> K_;
+
+  uint32_t width_;
+  uint32_t height_;
+
+  cv::Mat transform_;
+
+  void connectCb();
+
+  void imageCb(
+    const Image::ConstSharedPtr & depth_msg,
+    const Image::ConstSharedPtr & intensity_msg_in,
+    const CameraInfo::ConstSharedPtr & info_msg);
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyziRadialNode");
+};
+
+}  // namespace depth_image_proc
+
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_RADIAL_HPP_

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <image_geometry/pinhole_camera_model.h>
+#include <depth_image_proc/conversions.hpp>
+#include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/visibility.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <memory>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace depth_image_proc
+{
+
+namespace enc = sensor_msgs::image_encodings;
+
+class PointCloudXyzrgbNode : public rclcpp::Node
+{
+public:
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzrgbNode(const rclcpp::NodeOptions & options);
+
+private:
+  using PointCloud2 = sensor_msgs::msg::PointCloud2;
+  using Image = sensor_msgs::msg::Image;
+  using CameraInfo = sensor_msgs::msg::CameraInfo;
+
+  // Subscriptions
+  image_transport::SubscriberFilter sub_depth_, sub_rgb_;
+  message_filters::Subscriber<CameraInfo> sub_info_;
+  using SyncPolicy =
+    message_filters::sync_policies::ApproximateTime<Image, Image, CameraInfo>;
+  using ExactSyncPolicy =
+    message_filters::sync_policies::ExactTime<Image, Image, CameraInfo>;
+  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+  using ExactSynchronizer = message_filters::Synchronizer<ExactSyncPolicy>;
+  std::shared_ptr<Synchronizer> sync_;
+  std::shared_ptr<ExactSynchronizer> exact_sync_;
+
+  // Publications
+  std::mutex connect_mutex_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;
+
+  image_geometry::PinholeCameraModel model_;
+
+  void connectCb();
+
+  void imageCb(
+    const Image::ConstSharedPtr & depth_msg,
+    const Image::ConstSharedPtr & rgb_msg,
+    const CameraInfo::ConstSharedPtr & info_msg);
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzrgbNode");
+};
+
+}  // namespace depth_image_proc
+
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_

--- a/depth_image_proc/src/conversions.cpp
+++ b/depth_image_proc/src/conversions.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the Willow Garage nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "depth_image_proc/conversions.hpp"
+
+#include <limits>
+#include <vector>
+
+namespace depth_image_proc
+{
+
+// Handles float or uint16 depths
+template<typename T>
+void convertDepth(
+  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  const image_geometry::PinholeCameraModel & model,
+  double range_max)
+{
+  // Use correct principal point from calibration
+  float center_x = model.cx();
+  float center_y = model.cy();
+
+  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
+  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
+  float constant_x = unit_scaling / model.fx();
+  float constant_y = unit_scaling / model.fy();
+  float bad_point = std::numeric_limits<float>::quiet_NaN();
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
+  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
+  int row_step = depth_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
+      T depth = depth_row[u];
+
+      // Missing points denoted by NaNs
+      if (!DepthTraits<T>::valid(depth)) {
+        if (range_max != 0.0) {
+          depth = DepthTraits<T>::fromMeters(range_max);
+        } else {
+          *iter_x = *iter_y = *iter_z = bad_point;
+          continue;
+        }
+      }
+
+      // Fill in XYZ
+      *iter_x = (u - center_x) * depth * constant_x;
+      *iter_y = (v - center_y) * depth * constant_y;
+      *iter_z = DepthTraits<T>::toMeters(depth);
+    }
+  }
+}
+
+// Handles float or uint16 depths
+template<typename T>
+void convertDepthRadial(
+  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  cv::Mat & transform)
+{
+  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
+  float bad_point = std::numeric_limits<float>::quiet_NaN();
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
+  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
+  int row_step = depth_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
+      T depth = depth_row[u];
+
+      // Missing points denoted by NaNs
+      if (!DepthTraits<T>::valid(depth)) {
+        *iter_x = *iter_y = *iter_z = bad_point;
+        continue;
+      }
+      const cv::Vec3f & cvPoint = transform.at<cv::Vec3f>(u, v) * DepthTraits<T>::toMeters(depth);
+      // Fill in XYZ
+      *iter_x = cvPoint(0);
+      *iter_y = cvPoint(1);
+      *iter_z = cvPoint(2);
+    }
+  }
+}
+
+// Handles float or uint16 depths
+template<typename T>
+void convertIntensity(
+  const sensor_msgs::msg::Image::ConstSharedPtr & intensity_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg)
+{
+  sensor_msgs::PointCloud2Iterator<float> iter_i(*cloud_msg, "intensity");
+  const T * inten_row = reinterpret_cast<const T *>(&intensity_msg->data[0]);
+
+  const int i_row_step = intensity_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, inten_row += i_row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_i) {
+      *iter_i = inten_row[u];
+    }
+  }
+}
+
+void convertRgb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  int red_offset, int green_offset, int blue_offset, int color_step)
+{
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_r(*cloud_msg, "r");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_g(*cloud_msg, "g");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_b(*cloud_msg, "b");
+  const uint8_t * rgb = &rgb_msg->data[0];
+  int rgb_skip = rgb_msg->step - rgb_msg->width * color_step;
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, rgb += rgb_skip) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u,
+      rgb += color_step, ++iter_r, ++iter_g, ++iter_b)
+    {
+      *iter_r = rgb[red_offset];
+      *iter_g = rgb[green_offset];
+      *iter_b = rgb[blue_offset];
+    }
+  }
+}
+
+cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int height, bool radial)
+{
+  int i, j;
+  int totalsize = width * height;
+  cv::Mat pixelVectors(1, totalsize, CV_32FC3);
+  cv::Mat dst(1, totalsize, CV_32FC3);
+
+  cv::Mat sensorPoints(cv::Size(height, width), CV_32FC2);
+  cv::Mat undistortedSensorPoints(1, totalsize, CV_32FC2);
+
+  std::vector<cv::Mat> ch;
+  for (j = 0; j < height; j++) {
+    for (i = 0; i < width; i++) {
+      cv::Vec2f & p = sensorPoints.at<cv::Vec2f>(i, j);
+      p[0] = i;
+      p[1] = j;
+    }
+  }
+
+  sensorPoints = sensorPoints.reshape(2, 1);
+
+  cv::undistortPoints(sensorPoints, undistortedSensorPoints, cameraMatrix, distCoeffs);
+
+  ch.push_back(undistortedSensorPoints);
+  ch.push_back(cv::Mat::ones(1, totalsize, CV_32FC1));
+  cv::merge(ch, pixelVectors);
+
+  if (radial) {
+    for (i = 0; i < totalsize; i++) {
+      normalize(
+        pixelVectors.at<cv::Vec3f>(i),
+        dst.at<cv::Vec3f>(i));
+    }
+    pixelVectors = dst;
+  }
+  return pixelVectors.reshape(3, width);
+}
+
+}  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyz_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyz_radial.cpp
@@ -29,98 +29,22 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include "depth_image_proc/point_cloud_xyz_radial.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>
-#include <depth_image_proc/depth_conversions.hpp>
+#include <depth_image_proc/conversions.hpp>
 #include <depth_image_proc/visibility.h>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+
 #include <memory>
 #include <vector>
 #include <limits>
 
 namespace depth_image_proc
 {
-
-namespace enc = sensor_msgs::image_encodings;
-
-class PointCloudXyzRadialNode : public rclcpp::Node
-{
-public:
-  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzRadialNode(const rclcpp::NodeOptions & options);
-
-private:
-  // Subscriptions
-  image_transport::CameraSubscriber sub_depth_;
-  int queue_size_;
-
-  // Publications
-  std::mutex connect_mutex_;
-  using PointCloud = sensor_msgs::msg::PointCloud2;
-  rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;
-
-  std::vector<double> D_;
-  std::array<double, 9> K_;
-
-  uint32_t width_;
-  uint32_t height_;
-
-  cv::Mat binned;
-
-  void connectCb();
-
-  void depthCb(
-    const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-    const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);
-
-  // Handles float or uint16 depths
-  template<typename T>
-  void convert(
-    const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-    PointCloud::SharedPtr & cloud_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzRadialNode");
-};
-
-cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int height, bool radial)
-{
-  int i, j;
-  int totalsize = width * height;
-  cv::Mat pixelVectors(1, totalsize, CV_32FC3);
-  cv::Mat dst(1, totalsize, CV_32FC3);
-
-  cv::Mat sensorPoints(cv::Size(height, width), CV_32FC2);
-  cv::Mat undistortedSensorPoints(1, totalsize, CV_32FC2);
-
-  std::vector<cv::Mat> ch;
-  for (j = 0; j < height; j++) {
-    for (i = 0; i < width; i++) {
-      cv::Vec2f & p = sensorPoints.at<cv::Vec2f>(i, j);
-      p[0] = i;
-      p[1] = j;
-    }
-  }
-
-  sensorPoints = sensorPoints.reshape(2, 1);
-
-  cv::undistortPoints(sensorPoints, undistortedSensorPoints, cameraMatrix, distCoeffs);
-
-  ch.push_back(undistortedSensorPoints);
-  ch.push_back(cv::Mat::ones(1, totalsize, CV_32FC1));
-  cv::merge(ch, pixelVectors);
-
-  if (radial) {
-    for (i = 0; i < totalsize; i++) {
-      normalize(
-        pixelVectors.at<cv::Vec3f>(i),
-        dst.at<cv::Vec3f>(i));
-    }
-    pixelVectors = dst;
-  }
-  return pixelVectors.reshape(3, width);
-}
 
 
 PointCloudXyzRadialNode::PointCloudXyzRadialNode(const rclcpp::NodeOptions & options)
@@ -186,50 +110,20 @@ void PointCloudXyzRadialNode::depthCb(
     K_ = info_msg->k;
     width_ = info_msg->width;
     height_ = info_msg->height;
-    binned = initMatrix(cv::Mat_<double>(3, 3, &K_[0]), cv::Mat(D_), width_, height_, true);
+    transform_ = initMatrix(cv::Mat_<double>(3, 3, &K_[0]), cv::Mat(D_), width_, height_, true);
   }
 
+  // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == enc::TYPE_16UC1) {
-    convert<uint16_t>(depth_msg, cloud_msg);
+    convertDepthRadial<uint16_t>(depth_msg, cloud_msg, transform_);
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
-    convert<float>(depth_msg, cloud_msg);
+    convertDepthRadial<float>(depth_msg, cloud_msg, transform_);
   } else {
     RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
     return;
   }
 
   pub_point_cloud_->publish(*cloud_msg);
-}
-
-template<typename T>
-void PointCloudXyzRadialNode::convert(
-  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  PointCloud::SharedPtr & cloud_msg)
-{
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
-      T depth = depth_row[u];
-
-      // Missing points denoted by NaNs
-      if (!DepthTraits<T>::valid(depth)) {
-        *iter_x = *iter_y = *iter_z = bad_point;
-        continue;
-      }
-      const cv::Vec3f & cvPoint = binned.at<cv::Vec3f>(u, v) * DepthTraits<T>::toMeters(depth);
-      // Fill in XYZ
-      *iter_x = cvPoint(0);
-      *iter_y = cvPoint(1);
-      *iter_z = cvPoint(2);
-    }
-  }
 }
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -29,6 +29,7 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include "depth_image_proc/point_cloud_xyzi.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
@@ -40,9 +41,11 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/conversions.hpp>
 #include <depth_image_proc/visibility.h>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
+
 #include <memory>
 #include <string>
 #include <limits>
@@ -50,48 +53,6 @@
 namespace depth_image_proc
 {
 
-using namespace std::placeholders;
-namespace enc = sensor_msgs::image_encodings;
-
-class PointCloudXyziNode : public rclcpp::Node
-{
-public:
-  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyziNode(const rclcpp::NodeOptions & options);
-
-private:
-  using Image = sensor_msgs::msg::Image;
-  using CameraInfo = sensor_msgs::msg::CameraInfo;
-  using PointCloud = sensor_msgs::msg::PointCloud2;
-
-  // Subscriptions
-  image_transport::SubscriberFilter sub_depth_, sub_intensity_;
-  message_filters::Subscriber<CameraInfo> sub_info_;
-  using SyncPolicy =
-    message_filters::sync_policies::ApproximateTime<Image, Image, CameraInfo>;
-  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
-  std::shared_ptr<Synchronizer> sync_;
-
-  // Publications
-  std::mutex connect_mutex_;
-  rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;
-
-  image_geometry::PinholeCameraModel model_;
-
-  void connectCb();
-
-  void imageCb(
-    const Image::ConstSharedPtr & depth_msg,
-    const Image::ConstSharedPtr & intensity_msg,
-    const CameraInfo::ConstSharedPtr & info_msg);
-
-  template<typename T, typename T2>
-  void convert(
-    const Image::ConstSharedPtr & depth_msg,
-    const Image::ConstSharedPtr & intensity_msg,
-    const PointCloud::SharedPtr & cloud_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyziNode");
-};
 
 PointCloudXyziNode::PointCloudXyziNode(const rclcpp::NodeOptions & options)
 : Node("PointCloudXyziNode", options)
@@ -105,7 +66,13 @@ PointCloudXyziNode::PointCloudXyziNode(const rclcpp::NodeOptions & options)
     sub_depth_,
     sub_intensity_,
     sub_info_);
-  sync_->registerCallback(std::bind(&PointCloudXyziNode::imageCb, this, _1, _2, _3));
+  sync_->registerCallback(
+    std::bind(
+      &PointCloudXyziNode::imageCb,
+      this,
+      std::placeholders::_1,
+      std::placeholders::_2,
+      std::placeholders::_3));
 
   // Monitor whether anyone is subscribed to the output
   // TODO(ros2) Implement when SubscriberStatusCallback is available
@@ -230,74 +197,32 @@ void PointCloudXyziNode::imageCb(
     "z", 1, sensor_msgs::msg::PointField::FLOAT32,
     "intensity", 1, sensor_msgs::msg::PointField::FLOAT32);
 
-  if (depth_msg->encoding == enc::TYPE_16UC1 &&
-    intensity_msg->encoding == enc::MONO8)
-  {
-    convert<uint16_t, uint8_t>(depth_msg, intensity_msg, cloud_msg);
-  } else if (depth_msg->encoding == enc::TYPE_16UC1 && intensity_msg->encoding == enc::MONO16) {
-    convert<uint16_t, uint16_t>(depth_msg, intensity_msg, cloud_msg);
-  } else if (depth_msg->encoding == enc::TYPE_32FC1 && intensity_msg->encoding == enc::MONO8) {
-    convert<float, uint8_t>(depth_msg, intensity_msg, cloud_msg);
-  } else if (depth_msg->encoding == enc::TYPE_32FC1 && intensity_msg->encoding == enc::MONO16) {
-    convert<float, uint16_t>(depth_msg, intensity_msg, cloud_msg);
+  // Convert Depth Image to Pointcloud
+  if (depth_msg->encoding == enc::TYPE_16UC1) {
+    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
+  } else if (depth_msg->encoding == enc::TYPE_32FC1) {
+    convertDepth<float>(depth_msg, cloud_msg, model_);
   } else {
     RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
+    return;
+  }
+
+  // Convert Intensity Image to Pointcloud
+  if (intensity_msg->encoding == enc::MONO8) {
+    convertIntensity<uint8_t>(intensity_msg, cloud_msg);
+  } else if (intensity_msg->encoding == enc::MONO16) {
+    convertIntensity<uint16_t>(intensity_msg, cloud_msg);
+  } else if (intensity_msg->encoding == enc::TYPE_16UC1) {
+    convertIntensity<uint16_t>(intensity_msg, cloud_msg);
+  } else {
+    RCLCPP_ERROR(
+      logger_, "Intensity image has unsupported encoding [%s]", intensity_msg->encoding.c_str());
     return;
   }
 
   pub_point_cloud_->publish(*cloud_msg);
 }
 
-template<typename T, typename T2>
-void PointCloudXyziNode::convert(
-  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  const sensor_msgs::msg::Image::ConstSharedPtr & intensity_msg,
-  const PointCloud::SharedPtr & cloud_msg)
-{
-  // Use correct principal point from calibration
-  float center_x = model_.cx();
-  float center_y = model_.cy();
-
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
-  float constant_x = unit_scaling / model_.fx();
-  float constant_y = unit_scaling / model_.fy();
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-
-  const T2 * inten_row = reinterpret_cast<const T2 *>(&intensity_msg->data[0]);
-  int inten_row_step = intensity_msg->step / sizeof(T2);
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  sensor_msgs::PointCloud2Iterator<float> iter_i(*cloud_msg, "intensity");
-
-  for (int v = 0; v < static_cast<int>(cloud_msg->height);
-    ++v, depth_row += row_step, inten_row += inten_row_step)
-  {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width);
-      ++u, ++iter_x, ++iter_y, ++iter_z, ++iter_i)
-    {
-      T depth = depth_row[u];
-      T2 inten = inten_row[u];
-      // Check for invalid measurements
-      if (!DepthTraits<T>::valid(depth)) {
-        *iter_x = *iter_y = *iter_z = bad_point;
-      } else {
-        // Fill in XYZ
-        *iter_x = (u - center_x) * depth * constant_x;
-        *iter_y = (v - center_y) * depth * constant_y;
-        *iter_z = DepthTraits<T>::toMeters(depth);
-      }
-
-      // Fill in intensity
-      *iter_i = inten;
-    }
-  }
-}
 
 }  // namespace depth_image_proc
 

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -29,6 +29,7 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include "depth_image_proc/point_cloud_xyzrgb.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
@@ -41,9 +42,11 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>
+#include <depth_image_proc/conversions.hpp>
 #include <depth_image_proc/visibility.h>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
+
 #include <memory>
 #include <limits>
 #include <string>
@@ -52,53 +55,6 @@
 namespace depth_image_proc
 {
 
-using namespace std::placeholders;
-namespace enc = sensor_msgs::image_encodings;
-
-class PointCloudXyzrgbNode : public rclcpp::Node
-{
-public:
-  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzrgbNode(const rclcpp::NodeOptions & options);
-
-private:
-  using PointCloud2 = sensor_msgs::msg::PointCloud2;
-  using Image = sensor_msgs::msg::Image;
-  using CameraInfo = sensor_msgs::msg::CameraInfo;
-
-  // Subscriptions
-  image_transport::SubscriberFilter sub_depth_, sub_rgb_;
-  message_filters::Subscriber<CameraInfo> sub_info_;
-  using SyncPolicy =
-    message_filters::sync_policies::ApproximateTime<Image, Image, CameraInfo>;
-  using ExactSyncPolicy =
-    message_filters::sync_policies::ExactTime<Image, Image, CameraInfo>;
-  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
-  using ExactSynchronizer = message_filters::Synchronizer<ExactSyncPolicy>;
-  std::shared_ptr<Synchronizer> sync_;
-  std::shared_ptr<ExactSynchronizer> exact_sync_;
-
-  // Publications
-  std::mutex connect_mutex_;
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;
-
-  image_geometry::PinholeCameraModel model_;
-
-  void connectCb();
-
-  void imageCb(
-    const Image::ConstSharedPtr & depth_msg,
-    const Image::ConstSharedPtr & rgb_msg,
-    const CameraInfo::ConstSharedPtr & info_msg);
-
-  template<typename T>
-  void convert(
-    const Image::ConstSharedPtr & depth_msg,
-    const Image::ConstSharedPtr & rgb_msg,
-    const PointCloud2::SharedPtr & cloud_msg,
-    int red_offset, int green_offset, int blue_offset, int color_step);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzrgbNode");
-};
 
 PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
 : Node("PointCloudXyzrgbNode", options)
@@ -114,10 +70,22 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
       sub_depth_,
       sub_rgb_,
       sub_info_);
-    exact_sync_->registerCallback(std::bind(&PointCloudXyzrgbNode::imageCb, this, _1, _2, _3));
+    exact_sync_->registerCallback(
+      std::bind(
+        &PointCloudXyzrgbNode::imageCb,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3));
   } else {
     sync_ = std::make_shared<Synchronizer>(SyncPolicy(queue_size), sub_depth_, sub_rgb_, sub_info_);
-    sync_->registerCallback(std::bind(&PointCloudXyzrgbNode::imageCb, this, _1, _2, _3));
+    sync_->registerCallback(
+      std::bind(
+        &PointCloudXyzrgbNode::imageCb,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3));
   }
 
   // Monitor whether anyone is subscribed to the output
@@ -261,77 +229,29 @@ void PointCloudXyzrgbNode::imageCb(
   sensor_msgs::PointCloud2Modifier pcd_modifier(*cloud_msg);
   pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
 
+  // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == enc::TYPE_16UC1) {
-    convert<uint16_t>(
-      depth_msg, rgb_msg, cloud_msg, red_offset, green_offset, blue_offset,
-      color_step);
+    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
-    convert<float>(
-      depth_msg, rgb_msg, cloud_msg, red_offset, green_offset, blue_offset,
-      color_step);
+    convertDepth<float>(depth_msg, cloud_msg, model_);
   } else {
     RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
     return;
   }
 
-  pub_point_cloud_->publish(*cloud_msg);
-}
-
-template<typename T>
-void PointCloudXyzrgbNode::convert(
-  const Image::ConstSharedPtr & depth_msg,
-  const Image::ConstSharedPtr & rgb_msg,
-  const PointCloud2::SharedPtr & cloud_msg,
-  int red_offset, int green_offset, int blue_offset, int color_step)
-{
-  // Use correct principal point from calibration
-  float center_x = model_.cx();
-  float center_y = model_.cy();
-
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
-  float constant_x = unit_scaling / model_.fx();
-  float constant_y = unit_scaling / model_.fy();
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-  const uint8_t * rgb = &rgb_msg->data[0];
-  int rgb_skip = rgb_msg->step - rgb_msg->width * color_step;
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_r(*cloud_msg, "r");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_g(*cloud_msg, "g");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_b(*cloud_msg, "b");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_a(*cloud_msg, "a");
-
-  for (int v = 0; v < static_cast<int>(cloud_msg->height);
-    ++v, depth_row += row_step, rgb += rgb_skip)
-  {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width);
-      ++u, rgb += color_step, ++iter_x, ++iter_y, ++iter_z, ++iter_a, ++iter_r, ++iter_g, ++iter_b)
-    {
-      T depth = depth_row[u];
-
-      // Check for invalid measurements
-      if (!DepthTraits<T>::valid(depth)) {
-        *iter_x = *iter_y = *iter_z = bad_point;
-      } else {
-        // Fill in XYZ
-        *iter_x = (u - center_x) * depth * constant_x;
-        *iter_y = (v - center_y) * depth * constant_y;
-        *iter_z = DepthTraits<T>::toMeters(depth);
-      }
-
-      // Fill in color
-      *iter_a = 255;
-      *iter_r = rgb[red_offset];
-      *iter_g = rgb[green_offset];
-      *iter_b = rgb[blue_offset];
-    }
+  // Convert RGB
+  if (rgb_msg->encoding == enc::RGB8) {
+    convertRgb(rgb_msg, cloud_msg, red_offset, green_offset, blue_offset, color_step);
+  } else if (rgb_msg->encoding == enc::BGR8) {
+    convertRgb(rgb_msg, cloud_msg, red_offset, green_offset, blue_offset, color_step);
+  } else if (rgb_msg->encoding == enc::MONO8) {
+    convertRgb(rgb_msg, cloud_msg, red_offset, green_offset, blue_offset, color_step);
+  } else {
+    RCLCPP_ERROR(logger_, "RGB image has unsupported encoding [%s]", rgb_msg->encoding.c_str());
+    return;
   }
+
+  pub_point_cloud_->publish(*cloud_msg);
 }
 
 }  // namespace depth_image_proc


### PR DESCRIPTION
only changes `depth_image_proc`:
- migrate to use a more standard `.hpp` `.cpp` structure
- create a `conversions` file that holds converter methods for depth, rgb and intensity images

this shouldn't add/remove any end-functionality to the ros2 branch of this package...only housekeeping