### PR TITLE
support rgba8 and bgra8 encodings by skipping alpha channel

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
@@ -222,12 +222,26 @@ void PointCloudXyzrgbNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_ms
     blue_offset  = 2;
     color_step   = 3;
   }
+  if (rgb_msg->encoding == enc::RGBA8)
+  {
+    red_offset   = 0;
+    green_offset = 1;
+    blue_offset  = 2;
+    color_step   = 4;
+  }
   else if (rgb_msg->encoding == enc::BGR8)
   {
     red_offset   = 2;
     green_offset = 1;
     blue_offset  = 0;
     color_step   = 3;
+  }
+  else if (rgb_msg->encoding == enc::BGRA8)
+  {
+    red_offset   = 2;
+    green_offset = 1;
+    blue_offset  = 0;
+    color_step   = 4;
   }
   else if (rgb_msg->encoding == enc::MONO8)
   {

--- a/stereo_image_proc/src/libstereo_image_proc/processor.cpp
+++ b/stereo_image_proc/src/libstereo_image_proc/processor.cpp
@@ -194,12 +194,34 @@ void StereoProcessor::processPoints(const stereo_msgs::DisparityImage& disparity
       }
     }
   }
+  else if (encoding == enc::RGBA8) {
+    for (int32_t u = 0; u < dense_points_.rows; ++u) {
+      for (int32_t v = 0; v < dense_points_.cols; ++v) {
+        if (isValidPoint(dense_points_(u,v))) {
+          const cv::Vec4b& rgba = color.at<cv::Vec4b>(u,v);
+          int32_t rgb_packed = (rgba[0] << 16) | (rgba[1] << 8) | rgba[2];
+          points.channels[0].values.push_back(*(float*)(&rgb_packed));
+        }
+      }
+    }
+  }
   else if (encoding == enc::BGR8) {
     for (int32_t u = 0; u < dense_points_.rows; ++u) {
       for (int32_t v = 0; v < dense_points_.cols; ++v) {
         if (isValidPoint(dense_points_(u,v))) {
           const cv::Vec3b& bgr = color.at<cv::Vec3b>(u,v);
           int32_t rgb_packed = (bgr[2] << 16) | (bgr[1] << 8) | bgr[0];
+          points.channels[0].values.push_back(*(float*)(&rgb_packed));
+        }
+      }
+    }
+  }
+  else if (encoding == enc::BGRA8) {
+    for (int32_t u = 0; u < dense_points_.rows; ++u) {
+      for (int32_t v = 0; v < dense_points_.cols; ++v) {
+        if (isValidPoint(dense_points_(u,v))) {
+          const cv::Vec4b& bgra = color.at<cv::Vec4b>(u,v);
+          int32_t rgb_packed = (bgra[2] << 16) | (bgra[1] << 8) | bgra[0];
           points.channels[0].values.push_back(*(float*)(&rgb_packed));
         }
       }
@@ -295,12 +317,40 @@ void StereoProcessor::processPoints2(const stereo_msgs::DisparityImage& disparit
       }
     }
   }
+  else if (encoding == enc::RGBA8) {
+    for (int32_t u = 0; u < dense_points_.rows; ++u) {
+      for (int32_t v = 0; v < dense_points_.cols; ++v, ++i) {
+        if (isValidPoint(dense_points_(u,v))) {
+          const cv::Vec4b& rgba = color.at<cv::Vec4b>(u,v);
+          int32_t rgb_packed = (rgba[0] << 16) | (rgba[1] << 8) | rgba[2];
+          memcpy (&points.data[i * points.point_step + 12], &rgb_packed, sizeof (int32_t));
+        }
+        else {
+          memcpy (&points.data[i * points.point_step + 12], &bad_point, sizeof (float));
+        }
+      }
+    }
+  }
   else if (encoding == enc::BGR8) {
     for (int32_t u = 0; u < dense_points_.rows; ++u) {
       for (int32_t v = 0; v < dense_points_.cols; ++v, ++i) {
         if (isValidPoint(dense_points_(u,v))) {
           const cv::Vec3b& bgr = color.at<cv::Vec3b>(u,v);
           int32_t rgb_packed = (bgr[2] << 16) | (bgr[1] << 8) | bgr[0];
+          memcpy (&points.data[i * points.point_step + 12], &rgb_packed, sizeof (int32_t));
+        }
+        else {
+          memcpy (&points.data[i * points.point_step + 12], &bad_point, sizeof (float));
+        }
+      }
+    }
+  }
+  else if (encoding == enc::BGRA8) {
+    for (int32_t u = 0; u < dense_points_.rows; ++u) {
+      for (int32_t v = 0; v < dense_points_.cols; ++v, ++i) {
+        if (isValidPoint(dense_points_(u,v))) {
+          const cv::Vec4b& bgra = color.at<cv::Vec4b>(u,v);
+          int32_t rgb_packed = (bgra[2] << 16) | (bgra[1] << 8) | bgra[0];
           memcpy (&points.data[i * points.point_step + 12], &rgb_packed, sizeof (int32_t));
         }
         else {

--- a/stereo_image_proc/src/nodelets/point_cloud2.cpp
+++ b/stereo_image_proc/src/nodelets/point_cloud2.cpp
@@ -240,6 +240,22 @@ void PointCloud2Nodelet::imageCb(const ImageConstPtr& l_image_msg,
       }
     }
   }
+  else if (encoding == enc::RGBA8)
+  {
+    const cv::Mat_<cv::Vec4b> color(l_image_msg->height, l_image_msg->width,
+                                    (cv::Vec4b*)&l_image_msg->data[0],
+                                    l_image_msg->step);
+    for (int v = 0; v < mat.rows; ++v)
+    {
+      for (int u = 0; u < mat.cols; ++u, ++iter_r, ++iter_g, ++iter_b)
+      {
+        const cv::Vec4b& rgba = color(v,u);
+        *iter_r = rgba[0];
+        *iter_g = rgba[1];
+        *iter_b = rgba[2];
+      }
+    }
+  }
   else if (encoding == enc::BGR8)
   {
     const cv::Mat_<cv::Vec3b> color(l_image_msg->height, l_image_msg->width,
@@ -253,6 +269,22 @@ void PointCloud2Nodelet::imageCb(const ImageConstPtr& l_image_msg,
         *iter_r = bgr[2];
         *iter_g = bgr[1];
         *iter_b = bgr[0];
+      }
+    }
+  }
+  else if (encoding == enc::BGRA8)
+  {
+    const cv::Mat_<cv::Vec4b> color(l_image_msg->height, l_image_msg->width,
+                                    (cv::Vec4b*)&l_image_msg->data[0],
+                                    l_image_msg->step);
+    for (int v = 0; v < mat.rows; ++v)
+    {
+      for (int u = 0; u < mat.cols; ++u, ++iter_r, ++iter_g, ++iter_b)
+      {
+        const cv::Vec4b& bgra = color(v,u);
+        *iter_r = bgra[2];
+        *iter_g = bgra[1];
+        *iter_b = bgra[0];
       }
     }
   }


### PR DESCRIPTION
Added support for RGBA8 and BGRA8 encodings, similar to RGB8 & BGR8 and ignoring the alpha channel.
It is required because Images provided by CARLA simulator have BGRA8 encoding, and even when the image have sufficient data, it didn't work with it.