### PR TITLE
Replace deprecated geometry2 headers

### DIFF
--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -40,7 +40,7 @@
 #include <sensor_msgs/image_encodings.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 #include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <depth_image_proc/depth_traits.hpp>
 #include <depth_image_proc/visibility.h>
 #include <memory>

--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -39,7 +39,7 @@
 #include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <math.h>
 #include <memory>
 #include <string>


### PR DESCRIPTION
tf2_geometry_msgs.h was deprecated in https://github.com/ros2/geometry2/pull/418
tf2_eigen.h was deprecated in https://github.com/ros2/geometry2/pull/413

Signed-off-by: Jacob Perron <jacob@openrobotics.org>

This is an exact copy of #659 , but on a branch in the main repository.  This is to see if we can get CI to actually pass here.