### PR TITLE
Include vector

### DIFF
--- a/depth_image_proc/include/depth_image_proc/depth_traits.h
+++ b/depth_image_proc/include/depth_image_proc/depth_traits.h
@@ -36,6 +36,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 namespace depth_image_proc {
 


### PR DESCRIPTION
Include vector import to avoid `std::vector has not been declared` error.

Observed error when building a fork of `industrial_extrinsic_cal`.

```sh
Errors     << industrial_extrinsic_cal:make /ws/logs/industrial_extrinsic_cal/build.make.000.log                                                                                                                                                           
In file included from /ws/src/industrial_calibration/industrial_extrinsic_cal/include/industrial_extrinsic_cal/depth_proc_util.h:5:0,
                 from /ws/src/industrial_calibration/industrial_extrinsic_cal/src/depth_proc_util.cpp:1:
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:51:44: error: 'std::vector' has not been declared
   static inline void initializeBuffer(std::vector<uint8_t>& buffer) {} // Do nothing - already zero-filled
                                            ^~~~~~
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:51:50: error: expected ',' or '...' before '<' token
   static inline void initializeBuffer(std::vector<uint8_t>& buffer) {} // Do nothing - already zero-filled
                                                  ^
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:61:44: error: 'std::vector' has not been declared
   static inline void initializeBuffer(std::vector<uint8_t>& buffer)
                                            ^~~~~~
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:61:50: error: expected ',' or '...' before '<' token
   static inline void initializeBuffer(std::vector<uint8_t>& buffer)
                                                  ^
/opt/ros/melodic/include/depth_image_proc/depth_traits.h: In static member function 'static void depth_image_proc::DepthTraits<float>::initializeBuffer(int)':
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:63:46: error: 'buffer' was not declared in this scope
     float* start = reinterpret_cast<float*>(&buffer[0]);
                                              ^~~~~~
/opt/ros/melodic/include/depth_image_proc/depth_traits.h:63:46: note: suggested alternative: 'setbuffer'
     float* start = reinterpret_cast<float*>(&buffer[0]);
                                              ^~~~~~
                                              setbuffer
make[2]: *** [CMakeFiles/industrial_extrinsic_cal.dir/src/depth_proc_util.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/industrial_extrinsic_cal.dir/all] Error 2
make: *** [all] Error 2
```