### PR TITLE
Update setup.cfg to use underscores per setuptools preferred syntax

### DIFF
--- a/camera_calibration/setup.cfg
+++ b/camera_calibration/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/camera_calibration
+script_dir=$base/lib/camera_calibration
 [install]
-install-scripts=$base/lib/camera_calibration
+install_scripts=$base/lib/camera_calibration


### PR DESCRIPTION
When building this package from source using `colcon build`, `camera_calibration` produces the following warning:
```
--- stderr: camera_calibration
/home/admin/.local/lib/python3.8/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/home/admin/.local/lib/python3.8/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
---
```

This PR fixes the two lines that cause this issue in the package's `setup.cfg` file.