### PR TITLE
Fix loading `depth_image_proc::RegisterNode` as a component

### DIFF
--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -54,7 +54,7 @@ namespace enc = sensor_msgs::image_encodings;
 class RegisterNode : public rclcpp::Node
 {
 public:
-  DEPTH_IMAGE_PROC_PUBLIC RegisterNode();
+  DEPTH_IMAGE_PROC_PUBLIC RegisterNode(const rclcpp::NodeOptions& options);
 
 private:
   using Image = sensor_msgs::msg::Image;
@@ -93,8 +93,8 @@ private:
   rclcpp::Logger logger_ = rclcpp::get_logger("RegisterNode");
 };
 
-RegisterNode::RegisterNode()
-: Node("RegisterNode")
+RegisterNode::RegisterNode(const rclcpp::NodeOptions& options)
+: Node("RegisterNode", options)
 {
   rclcpp::Clock::SharedPtr clock = this->get_clock();
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
@@ -271,7 +271,7 @@ void RegisterNode::convert(
 
 }  // namespace depth_image_proc
 
-#include "class_loader/register_macro.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
 
 // Register the component with class_loader.
-CLASS_LOADER_REGISTER_CLASS(depth_image_proc::RegisterNode, rclcpp::Node)
+RCLCPP_COMPONENTS_REGISTER_NODE(depth_image_proc::RegisterNode)


### PR DESCRIPTION
All the nodes in the `depth_image_proc` are registered as components, except for `depth_image_proc::RegisterNode`. I think this might have been an oversight in #543.

This replaces the `CLASS_LOADER_REGISTER_CLASS` macro with the `RCLCPP_COMPONENTS_REGISTER_NODE` macro and updates its constructor, which allows this node to be loaded in a ComposableNodeContainer.