### PR TITLE
Port upsampling interpolation from #363 to ROS2

### DIFF
--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -241,8 +241,7 @@ void RegisterNode::convert(
 
       double depth = DepthTraits<T>::toMeters(raw_depth);
 
-      if (fill_upsampling_holes_ == false)
-      {
+      if (fill_upsampling_holes_ == false) {
         /// @todo Combine all operations into one matrix multiply on (u,v,d)
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth;
@@ -259,18 +258,18 @@ void RegisterNode::convert(
         int u_rgb = (rgb_fx*xyz_rgb.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
         int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
 
-        if (u_rgb < 0 || u_rgb >= (int)registered_msg->width ||
-            v_rgb < 0 || v_rgb >= (int)registered_msg->height)
+        if (u_rgb < 0 || u_rgb >= static_cast<int>(registered_msg->width) ||
+            v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height)) {
           continue;
+        }
 
-        T& reg_depth = registered_data[v_rgb*registered_msg->width + u_rgb];
-        T  new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
+        T & reg_depth = registered_data[v_rgb*registered_msg->width + u_rgb];
+        T new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
         // Validity and Z-buffer checks
-        if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth)
+        if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
           reg_depth = new_depth;
-      }
-      else
-      {
+        }
+      } else {
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth_1, xyz_depth_2;
         xyz_depth_1 << ((u-0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
@@ -294,19 +293,19 @@ void RegisterNode::convert(
         int u_rgb_2 = (rgb_fx*xyz_rgb_2.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
         int v_rgb_2 = (rgb_fy*xyz_rgb_2.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
 
-        if (u_rgb_1 < 0 || u_rgb_2 >= (int)registered_msg->width ||
-            v_rgb_1 < 0 || v_rgb_2 >= (int)registered_msg->height)
+        if (u_rgb_1 < 0 || u_rgb_2 >= static_cast<int>(registered_msg->width) ||
+            v_rgb_1 < 0 || v_rgb_2 >= static_cast<int>(registered_msg->height)) {
           continue;
+        }
 
-        for (int nv=v_rgb_1; nv<=v_rgb_2; ++nv)
-        {
-          for (int nu=u_rgb_1; nu<=u_rgb_2; ++nu)
-          {
-            T& reg_depth = registered_data[nv*registered_msg->width + nu];
-            T  new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
+        for (int nv = v_rgb_1; nv <= v_rgb_2; ++nv) {
+          for (int nu = u_rgb_1; nu <= u_rgb_2; ++nu) {
+            T & reg_depth = registered_data[nv*registered_msg->width + nu];
+            T new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
             // Validity and Z-buffer checks
-            if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth)
+            if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
               reg_depth = new_depth;
+            }
           }
         }
       }

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -77,6 +77,9 @@ private:
 
   image_geometry::PinholeCameraModel depth_model_, rgb_model_;
 
+  // Parameters
+  bool fill_upsampling_holes_;
+
   void connectCb();
 
   void imageCb(
@@ -102,6 +105,7 @@ RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
 
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
+  fill_upsampling_holes_ = this->declare_parameter<bool>("fill_upsampling_holes", false);
 
   // Synchronize inputs. Topic subscriptions happen on demand in the connection callback.
   sync_ = std::make_shared<Synchronizer>(
@@ -237,33 +241,74 @@ void RegisterNode::convert(
 
       double depth = DepthTraits<T>::toMeters(raw_depth);
 
-      /// @todo Combine all operations into one matrix multiply on (u,v,d)
-      // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
-      Eigen::Vector4d xyz_depth;
-      xyz_depth << ((u - depth_cx) * depth - depth_Tx) * inv_depth_fx,
-      ((v - depth_cy) * depth - depth_Ty) * inv_depth_fy,
-        depth,
-        1;
-
-      // Transform to RGB camera frame
-      Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
-
-      // Project to (u,v) in RGB image
-      double inv_Z = 1.0 / xyz_rgb.z();
-      int u_rgb = (rgb_fx * xyz_rgb.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
-      int v_rgb = (rgb_fy * xyz_rgb.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
-
-      if (u_rgb < 0 || u_rgb >= static_cast<int>(registered_msg->width) ||
-        v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height))
+      if (fill_upsampling_holes_ == false)
       {
-        continue;
-      }
+        /// @todo Combine all operations into one matrix multiply on (u,v,d)
+        // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
+        Eigen::Vector4d xyz_depth;
+        xyz_depth << ((u - depth_cx)*depth - depth_Tx) * inv_depth_fx,
+                     ((v - depth_cy)*depth - depth_Ty) * inv_depth_fy,
+                     depth,
+                     1;
 
-      T & reg_depth = registered_data[v_rgb * registered_msg->width + u_rgb];
-      T new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
-      // Validity and Z-buffer checks
-      if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
-        reg_depth = new_depth;
+        // Transform to RGB camera frame
+        Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
+
+        // Project to (u,v) in RGB image
+        double inv_Z = 1.0 / xyz_rgb.z();
+        int u_rgb = (rgb_fx*xyz_rgb.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
+        int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+
+        if (u_rgb < 0 || u_rgb >= (int)registered_msg->width ||
+            v_rgb < 0 || v_rgb >= (int)registered_msg->height)
+          continue;
+
+        T& reg_depth = registered_data[v_rgb*registered_msg->width + u_rgb];
+        T  new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
+        // Validity and Z-buffer checks
+        if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth)
+          reg_depth = new_depth;
+      }
+      else
+      {
+        // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
+        Eigen::Vector4d xyz_depth_1, xyz_depth_2;
+        xyz_depth_1 << ((u-0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
+                       ((v-0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
+                       depth,
+                       1;
+        xyz_depth_2 << ((u+0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
+                       ((v+0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
+                       depth,
+                       1;
+
+        // Transform to RGB camera frame
+        Eigen::Vector4d xyz_rgb_1 = depth_to_rgb * xyz_depth_1;
+        Eigen::Vector4d xyz_rgb_2 = depth_to_rgb * xyz_depth_2;
+
+        // Project to (u,v) in RGB image
+        double inv_Z = 1.0 / xyz_rgb_1.z();
+        int u_rgb_1 = (rgb_fx*xyz_rgb_1.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
+        int v_rgb_1 = (rgb_fy*xyz_rgb_1.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+        inv_Z = 1.0 / xyz_rgb_2.z();
+        int u_rgb_2 = (rgb_fx*xyz_rgb_2.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
+        int v_rgb_2 = (rgb_fy*xyz_rgb_2.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+
+        if (u_rgb_1 < 0 || u_rgb_2 >= (int)registered_msg->width ||
+            v_rgb_1 < 0 || v_rgb_2 >= (int)registered_msg->height)
+          continue;
+
+        for (int nv=v_rgb_1; nv<=v_rgb_2; ++nv)
+        {
+          for (int nu=u_rgb_1; nu<=u_rgb_2; ++nu)
+          {
+            T& reg_depth = registered_data[nv*registered_msg->width + nu];
+            T  new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
+            // Validity and Z-buffer checks
+            if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth)
+              reg_depth = new_depth;
+          }
+        }
       }
     }
   }

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -245,25 +245,26 @@ void RegisterNode::convert(
         /// @todo Combine all operations into one matrix multiply on (u,v,d)
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth;
-        xyz_depth << ((u - depth_cx)*depth - depth_Tx) * inv_depth_fx,
-                     ((v - depth_cy)*depth - depth_Ty) * inv_depth_fy,
-                     depth,
-                     1;
+        xyz_depth << ((u - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
 
         // Transform to RGB camera frame
         Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
 
         // Project to (u,v) in RGB image
         double inv_Z = 1.0 / xyz_rgb.z();
-        int u_rgb = (rgb_fx*xyz_rgb.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+        int u_rgb = (rgb_fx * xyz_rgb.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb = (rgb_fy * xyz_rgb.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
 
         if (u_rgb < 0 || u_rgb >= static_cast<int>(registered_msg->width) ||
-            v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height)) {
+          v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height))
+        {
           continue;
         }
 
-        T & reg_depth = registered_data[v_rgb*registered_msg->width + u_rgb];
+        T & reg_depth = registered_data[v_rgb * registered_msg->width + u_rgb];
         T new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
         // Validity and Z-buffer checks
         if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
@@ -272,14 +273,14 @@ void RegisterNode::convert(
       } else {
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth_1, xyz_depth_2;
-        xyz_depth_1 << ((u-0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
-                       ((v-0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
-                       depth,
-                       1;
-        xyz_depth_2 << ((u+0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
-                       ((v+0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
-                       depth,
-                       1;
+        xyz_depth_1 << ((u - 0.5f - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v - 0.5f - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
+        xyz_depth_2 << ((u + 0.5f - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v + 0.5f - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
 
         // Transform to RGB camera frame
         Eigen::Vector4d xyz_rgb_1 = depth_to_rgb * xyz_depth_1;
@@ -287,21 +288,22 @@ void RegisterNode::convert(
 
         // Project to (u,v) in RGB image
         double inv_Z = 1.0 / xyz_rgb_1.z();
-        int u_rgb_1 = (rgb_fx*xyz_rgb_1.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb_1 = (rgb_fy*xyz_rgb_1.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+        int u_rgb_1 = (rgb_fx * xyz_rgb_1.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb_1 = (rgb_fy * xyz_rgb_1.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
         inv_Z = 1.0 / xyz_rgb_2.z();
-        int u_rgb_2 = (rgb_fx*xyz_rgb_2.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb_2 = (rgb_fy*xyz_rgb_2.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+        int u_rgb_2 = (rgb_fx * xyz_rgb_2.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb_2 = (rgb_fy * xyz_rgb_2.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
 
         if (u_rgb_1 < 0 || u_rgb_2 >= static_cast<int>(registered_msg->width) ||
-            v_rgb_1 < 0 || v_rgb_2 >= static_cast<int>(registered_msg->height)) {
+          v_rgb_1 < 0 || v_rgb_2 >= static_cast<int>(registered_msg->height))
+        {
           continue;
         }
 
         for (int nv = v_rgb_1; nv <= v_rgb_2; ++nv) {
           for (int nu = u_rgb_1; nu <= u_rgb_2; ++nu) {
-            T & reg_depth = registered_data[nv*registered_msg->width + nu];
-            T new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
+            T & reg_depth = registered_data[nv * registered_msg->width + nu];
+            T new_depth = DepthTraits<T>::fromMeters(0.5 * (xyz_rgb_1.z() + xyz_rgb_2.z()));
             // Validity and Z-buffer checks
             if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
               reg_depth = new_depth;


### PR DESCRIPTION
Add the algorithm updates and new parameters from #363 (which is included in the `noetic` branch, but not the ROS2 branches) to allow interpolating the upscaled depth image when registering it to an image of higher resolution.

Like the original PR, this includes a bool parameter that is `false` by default to preserve the original functionality of this node. However, I'm not sure if there's a use case in which a user would want to purposefully leave the gaps in the depth image.