### PR TITLE
Fix ResizeNode to allow remapping both image and camera_info topics

### DIFF
--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -51,10 +51,10 @@ ResizeNode::ResizeNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ResizeNode", options)
 {
   // Create image pub
-  pub_image_ = image_transport::create_camera_publisher(this, "resize");
+  pub_image_ = image_transport::create_camera_publisher(this, "resize/image_raw");
   // Create image sub
   sub_image_ = image_transport::create_camera_subscription(
-    this, "image",
+    this, "image/image_raw",
     std::bind(
       &ResizeNode::imageCb, this,
       std::placeholders::_1,


### PR DESCRIPTION
Due to how `image_transport::create_camera_subscription` creates a `camera_info` topic from the provided image topic name, the current implementation of `image_proc::ResizeNode` ends up using the same topic name `/camera_info` for both the input image subscriber and the output resized image publisher. This prevents remapping the input and output CameraInfo topics.

This change makes `image` and `resize` topic namespaces instead of image topic names, which allows the node to correctly separately use `/image/camera_info` and `/resize/camera_info`.