### PR TITLE
Fix image saver bug and time-based image saving

### DIFF
--- a/image_view/include/image_view/image_saver_node.hpp
+++ b/image_view/include/image_view/image_saver_node.hpp
@@ -70,12 +70,13 @@ public:
 
 private:
   boost::format g_format;
-  bool save_all_image, save_image_service;
-  std::string encoding;
-  bool request_start_end;
-  bool is_first_image_;
-  bool has_camera_info_;
-  size_t count_;
+  bool save_all_image_{false};
+  bool save_image_service_{false};
+  std::string encoding_;
+  bool request_start_end_{false};
+  bool is_first_image_{true};
+  bool has_camera_info_{false};
+  size_t count_{0u};
   rclcpp::Time start_time_;
   rclcpp::Time end_time_;
   image_transport::CameraSubscriber cam_sub_;


### PR DESCRIPTION
Add missing 'request_start_end' ROS parameter (from ROS 1) and ensure related
member variables are initialized properly. This restores the time-based image
saving feature from ROS 1 and fixes a bug where member variables
'save_image_service' and 'request_start_end' were not initialized properly
which could lead to images not properly saving.

I've also renamed some member variables to have a trailing underscore, for
consistency with other members.