### PR TITLE
Fix includes

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyz_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyz_radial.cpp
@@ -36,6 +36,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <image_geometry/pinhole_camera_model.h>
+#include <opencv2/calib3d/calib3d.hpp>
 #include <boost/thread.hpp>
 #include <depth_image_proc/depth_traits.h>
 

--- a/depth_image_proc/src/nodelets/point_cloud_xyzi_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzi_radial.cpp
@@ -40,6 +40,7 @@
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
 #include <image_geometry/pinhole_camera_model.h>
+#include <opencv2/calib3d/calib3d.hpp>
 #include <boost/thread.hpp>
 #include <depth_image_proc/depth_traits.h>
 

--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
@@ -42,6 +42,7 @@
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <image_geometry/pinhole_camera_model.h>
+#include <opencv2/calib3d/calib3d.hpp>
 #include <boost/thread.hpp>
 #include <depth_image_proc/depth_traits.h>
 

--- a/stereo_image_proc/include/stereo_image_proc/processor.h
+++ b/stereo_image_proc/include/stereo_image_proc/processor.h
@@ -36,6 +36,7 @@
 
 #include <image_proc/processor.h>
 #include <image_geometry/stereo_camera_model.h>
+#include <opencv2/calib3d/calib3d.hpp>
 #include <stereo_msgs/DisparityImage.h>
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>


### PR DESCRIPTION
In the following commit in `vision_opencv`, the include `opencv2/calib3d/calib3d.hpp` was removed from `pinhole_camera_model.h`:

https://github.com/ros-perception/vision_opencv/commit/51ca54354a8353fc728fcc8bd8ead7d2b6cf7444

Since we indirectly depended on this include, we now have to add it directly, otherwise our repo will fail to compile once the next release of `vision_opencv` happens.