### PR TITLE
[rolling] Populate CameraInfo camera matrix in test fixture

### DIFF
--- a/stereo_image_proc/test/fixtures/stereo_image_publisher.py
+++ b/stereo_image_proc/test/fixtures/stereo_image_publisher.py
@@ -90,6 +90,11 @@ class StereoImagePublisher(Node):
         camera_info_msg = CameraInfo()
         camera_info_msg.height = image.shape[0]
         camera_info_msg.width = image.shape[1]
+        camera_info_msg.p = [
+            1.0, 0.0, 1.0, 0.0,
+            0.0, 1.0, 1.0, 0.0,
+            0.0, 0.0, 1.0, 0.0
+        ]
 
         return (image_msg, camera_info_msg)
 


### PR DESCRIPTION
By adding non-zero values we avoid a divide by zero during stereo processing and avoid an issue
leading to rclpy to crash: https://github.com/ros2/rclpy/issues/848
