### PR TITLE
Delete line 330 in calibrator.py 

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -327,7 +327,6 @@ class Calibrator():
         self.checkerboard_flags = checkerboard_flags
         self.pattern = pattern
         self.br = cv_bridge.CvBridge()
-        self.camera_model = CAMERA_MODEL.PINHOLE
         # self.db is list of (parameters, image) samples for use in calibration. parameters has form
         # (X, Y, size, skew) all normalized to [0,1], to keep track of what sort of samples we've taken
         # and ensure enough variety.


### PR DESCRIPTION
Unable to selected fisheye option during camera_calibration since CAMERA_MODEL.PINHOLE is hardcoded on line 330. This should be set by set_cammodel. Removing this line allows switching between the two options via the GUI.