### PR TITLE
Printout fixes (topic names, ros2 help), exception fixes

### DIFF
--- a/image_view/src/disparity_view_node.cpp
+++ b/image_view/src/disparity_view_node.cpp
@@ -70,7 +70,7 @@ DisparityViewNode::DisparityViewNode(const rclcpp::NodeOptions & options)
   if (topic == "image") {
     RCLCPP_WARN(
       this->get_logger(), "Topic 'image' has not been remapped! Typical command-line usage:\n"
-      "\t$ rosrun image_view disparity_view image:=<disparity image topic>");
+      "\t$ ros2 run image_view disparity_view --ros-args -r image:=<disparity image topic>");
   }
 
   initialized = false;

--- a/image_view/src/extract_images.cpp
+++ b/image_view/src/extract_images.cpp
@@ -59,7 +59,6 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions options;
-  options.append_parameter_override("transport", (argc > 1) ? argv[1] : "raw");
   auto ein = std::make_shared<ExtractImagesNode>(options);
 
   rclcpp::spin(ein);

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -84,7 +84,8 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
   if (topics.find(topic) != topics.end()) {
     RCLCPP_WARN(
       this->get_logger(), "extract_images: image has not been remapped! "
-      "Typical command-line usage:\n\t$ ros2 run image_view extract_images --ros-args -r image:=<image topic> -p transport:=<transport mode>");
+      "Typical command-line usage:\n\t$ ros2 run image_view extract_images "
+      "--ros-args -r image:=<image topic> -p transport:=<transport mode>");
   }
 
   this->declare_parameter<std::string>("filename_format", std::string("frame%04i.jpg"));

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -71,7 +71,8 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
   auto topic = rclcpp::expand_topic_or_service_name(
     "image", this->get_name(), this->get_namespace());
 
-  std::string transport = this->declare_parameter("transport", std::string("raw"));
+  this->declare_parameter<std::string>("transport", std::string("raw"));
+  std::string transport = this->get_parameter("transport").as_string();
 
   sub_ = image_transport::create_subscription(
     this, topic, std::bind(
@@ -83,14 +84,15 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
   if (topics.find(topic) != topics.end()) {
     RCLCPP_WARN(
       this->get_logger(), "extract_images: image has not been remapped! "
-      "Typical command-line usage:\n\t$ ./extract_images image:=<image topic> [transport]");
+      "Typical command-line usage:\n\t$ ros2 run image_view extract_images --ros-args -r image:=<image topic> -p transport:=<transport mode>");
   }
 
-  std::string format_string =
-    this->declare_parameter("filename_format", std::string("frame%04i.jpg"));
+  this->declare_parameter<std::string>("filename_format", std::string("frame%04i.jpg"));
+  std::string format_string = this->get_parameter("filename_format").as_string();
   filename_format_.parse(format_string);
 
-  double sec_per_frame_ = this->declare_parameter("sec_per_frame", 0.1);
+  this->declare_parameter<double>("sec_per_frame", 0.1);
+  sec_per_frame_ = this->get_parameter("sec_per_frame").as_double();
 
   RCLCPP_INFO(this->get_logger(), "Initialized sec per frame to %f", sec_per_frame_);
 }

--- a/image_view/src/stereo_view.cpp
+++ b/image_view/src/stereo_view.cpp
@@ -59,7 +59,6 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions options;
-  options.append_parameter_override("transport", (argc > 1) ? argv[1] : "raw");
   auto svn = std::make_shared<StereoViewNode>(options);
 
   rclcpp::spin(svn);

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -163,10 +163,11 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
       std::bind(&StereoViewNode::imageCb, this, _1, _2, _3));
   }
 
-  for (auto const& x : topics) {
+  for (auto const & x : topics) {
     if (x.first.find("/stereo/left/image") != std::string::npos ||
       x.first.find("/stereo/right/image") != std::string::npos ||
-      x.first.find("/stereo/disparity") != std::string::npos) {
+      x.first.find("/stereo/disparity") != std::string::npos)
+    {
       RCLCPP_WARN(
         this->get_logger(), "defaults topics '/stereo/xxx' have not been remapped! "
         "Example command-line usage:\n"

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -170,7 +170,8 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
         x.first.find("/stereo/disparity") != std::string::npos)
     {
       RCLCPP_WARN(
-       this->get_logger(), "defaults topics '/stereo/xxx' have not been remapped! Example command-line usage:\n"
+       this->get_logger(), "defaults topics '/stereo/xxx' have not been remapped! "
+        "Example command-line usage:\n"
         "\t$ ros2 run image_view stereo_view --ros-args "
         "-r /stereo/left/image:=/narrow_stereo/left/color_raw "
         "-r /stereo/right/image:=/narrow_stereo/right/color_raw "

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -163,14 +163,12 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
       std::bind(&StereoViewNode::imageCb, this, _1, _2, _3));
   }
 
-  for (auto const& x : topics)
-  {
+  for (auto const& x : topics) {
     if (x.first.find("/stereo/left/image") != std::string::npos ||
-        x.first.find("/stereo/right/image") != std::string::npos ||
-        x.first.find("/stereo/disparity") != std::string::npos)
-    {
+      x.first.find("/stereo/right/image") != std::string::npos ||
+      x.first.find("/stereo/disparity") != std::string::npos) {
       RCLCPP_WARN(
-       this->get_logger(), "defaults topics '/stereo/xxx' have not been remapped! "
+        this->get_logger(), "defaults topics '/stereo/xxx' have not been remapped! "
         "Example command-line usage:\n"
         "\t$ ros2 run image_view stereo_view --ros-args "
         "-r /stereo/left/image:=/narrow_stereo/left/color_raw "


### PR DESCRIPTION
- Rewrite some of the `rosrun` help left from ROS1
- Use `transport` as a ros arg parameter instead of a cli arg
    - Before: `ros2 run image_view extract_images transport:=raw` would break if adding `--ros-args -r image:=image_raw`
    - Now: `ros2 run image_view extract_images --ros-args -r image:=image_raw -p transport:=raw` which uses the API's capabilities
- `stereo_view_node` would throw an exception because of a double trailing slash in the topic name