### PR TITLE
bring over ros1 fix for missing roi resize

### DIFF
--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -125,6 +125,11 @@ void ResizeNode::imageCb(
   dst_info_msg->p[5] = dst_info_msg->p[5] * scale_y;  // fy
   dst_info_msg->p[6] = dst_info_msg->p[6] * scale_y;  // cy
 
+  dst_info_msg->roi.x_offset = static_cast<int>(dst_info_msg->roi.x_offset * scale_x);
+  dst_info_msg->roi.y_offset = static_cast<int>(dst_info_msg->roi.y_offset * scale_y);
+  dst_info_msg->roi.width = static_cast<int>(dst_info_msg->roi.width * scale_x);
+  dst_info_msg->roi.height = static_cast<int>(dst_info_msg->roi.height * scale_y);
+
   pub_image_.publish(*cv_ptr->toImageMsg(), *dst_info_msg);
 }
 


### PR DESCRIPTION
Brings over [ROS 1 ROI resize fix](https://github.com/ros-perception/image_pipeline/pull/716).

Only tested if it compiles, but should be fine I think.

cc @furushchev @JWhitleyWork 

Signed-off-by: Evan Flynn <evan.flynn@apex.ai>