### PR TITLE
depth_image_proc register cover all angles with fill_upsampling_holes

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -54,3 +54,10 @@ install(TARGETS ${PROJECT_NAME}
 install(FILES nodelet_plugins.xml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+
+  add_rostest(test/test_register.test
+    DEPENDENCIES ${${PROJECT_NAME}_EXPORTED_TARGETS})
+endif()

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -45,4 +45,7 @@
   <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>sensor_msgs</run_depend>
+
+  <test_depend>rostest</test_depend>
+  <test_depend>tf</test_depend>
 </package>

--- a/depth_image_proc/src/nodelets/register.cpp
+++ b/depth_image_proc/src/nodelets/register.cpp
@@ -285,6 +285,9 @@ void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
           continue;
 
         // TODO(lucasw) this is identical to above except adding 0.5 instead of subtracting
+        // TODO(lucasw) need a third and fourth position with u+0.5 and v-0.5 and u-0.5 and v+0.5
+        // (and then could do the triangle rastering mentioned above, or just take the min
+        // and max of all of them)
         xyz_depth_2 << ((u+0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
                        ((v+0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
                        depth,
@@ -302,9 +305,9 @@ void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
 
         // fill in the square defined by uv range
         const T new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
-        for (int nv=v_rgb_1; nv<=v_rgb_2; ++nv)
+        for (int nv=std::min(v_rgb_1, v_rgb_2); nv<=std::max(v_rgb_1, v_rgb_2); ++nv)
         {
-          for (int nu=u_rgb_1; nu<=u_rgb_2; ++nu)
+          for (int nu=std::min(u_rgb_1, u_rgb_2); nu<=std::max(u_rgb_2, u_rgb_2); ++nu)
           {
             T& reg_depth = registered_data[nv*registered_msg->width + nu];
             // Validity and Z-buffer checks

--- a/depth_image_proc/src/nodelets/register.cpp
+++ b/depth_image_proc/src/nodelets/register.cpp
@@ -247,9 +247,6 @@ bool transform_depth(
   return true;
 }
 
-// TODO(lucasw) need a unit test for this, simple low res image (e.g. 4x4 pixels) with
-// depth ranges of around 1.0
-// shift it to the right 1.0 units, view from 90 degrees
 template<typename T>
 void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
                               const sensor_msgs::ImagePtr& registered_msg,

--- a/depth_image_proc/src/nodelets/register.cpp
+++ b/depth_image_proc/src/nodelets/register.cpp
@@ -195,6 +195,9 @@ void RegisterNodelet::imageCb(const sensor_msgs::ImageConstPtr& depth_image_msg,
   pub_registered_.publish(registered_msg, registered_info_msg);
 }
 
+// TODO(lucasw) need a unit test for this, simple low res image (e.g. 4x4 pixels) with
+// depth ranges of around 1.0
+// shift it to the right 1.0 units, view from 90 degrees
 template<typename T>
 void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
                               const sensor_msgs::ImagePtr& registered_msg,
@@ -207,32 +210,33 @@ void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
   DepthTraits<T>::initializeBuffer(registered_msg->data);
 
   // Extract all the parameters we need
-  double inv_depth_fx = 1.0 / depth_model_.fx();
-  double inv_depth_fy = 1.0 / depth_model_.fy();
-  double depth_cx = depth_model_.cx(), depth_cy = depth_model_.cy();
-  double depth_Tx = depth_model_.Tx(), depth_Ty = depth_model_.Ty();
-  double rgb_fx = rgb_model_.fx(), rgb_fy = rgb_model_.fy();
-  double rgb_cx = rgb_model_.cx(), rgb_cy = rgb_model_.cy();
-  double rgb_Tx = rgb_model_.Tx(), rgb_Ty = rgb_model_.Ty();
+  const double inv_depth_fx = 1.0 / depth_model_.fx();
+  const double inv_depth_fy = 1.0 / depth_model_.fy();
+  const double depth_cx = depth_model_.cx(), depth_cy = depth_model_.cy();
+  const double depth_Tx = depth_model_.Tx(), depth_Ty = depth_model_.Ty();
+  const double rgb_fx = rgb_model_.fx(), rgb_fy = rgb_model_.fy();
+  const double rgb_cx = rgb_model_.cx(), rgb_cy = rgb_model_.cy();
+  const double rgb_Tx = rgb_model_.Tx(), rgb_Ty = rgb_model_.Ty();
   
   // Transform the depth values into the RGB frame
   /// @todo When RGB is higher res, interpolate by rasterizing depth triangles onto the registered image  
   const T* depth_row = reinterpret_cast<const T*>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
+  const int row_step = depth_msg->step / sizeof(T);
   T* registered_data = reinterpret_cast<T*>(&registered_msg->data[0]);
   int raw_index = 0;
   for (unsigned v = 0; v < depth_msg->height; ++v, depth_row += row_step)
   {
     for (unsigned u = 0; u < depth_msg->width; ++u, ++raw_index)
     {
-      T raw_depth = depth_row[u];
+      const T raw_depth = depth_row[u];
       if (!DepthTraits<T>::valid(raw_depth))
         continue;
-      
-      double depth = DepthTraits<T>::toMeters(raw_depth);
+
+      const double depth = DepthTraits<T>::toMeters(raw_depth);
 
       if (fill_upsampling_holes_ == false)
       {
+        // TODO(lucasw) factor out common code below
         /// @todo Combine all operations into one matrix multiply on (u,v,d)
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth;
@@ -247,12 +251,13 @@ void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
         // Project to (u,v) in RGB image
         double inv_Z = 1.0 / xyz_rgb.z();
         int u_rgb = (rgb_fx*xyz_rgb.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
-      
-        if (u_rgb < 0 || u_rgb >= (int)registered_msg->width ||
-            v_rgb < 0 || v_rgb >= (int)registered_msg->height)
+        if (u_rgb < 0 || u_rgb >= (int)registered_msg->width)
           continue;
-      
+
+        int v_rgb = (rgb_fy*xyz_rgb.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
+        if (v_rgb < 0 || v_rgb >= (int)registered_msg->height)
+          continue;
+
         T& reg_depth = registered_data[v_rgb*registered_msg->width + u_rgb];
         T  new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
         // Validity and Z-buffer checks
@@ -261,39 +266,47 @@ void RegisterNodelet::convert(const sensor_msgs::ImageConstPtr& depth_msg,
       }
       else
       {
+        // TODO(lucasw) replace same code with for loop
         // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
         Eigen::Vector4d xyz_depth_1, xyz_depth_2;
         xyz_depth_1 << ((u-0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
                        ((v-0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
                        depth,
                        1;
+        // Transform to RGB camera frame
+        Eigen::Vector4d xyz_rgb_1 = depth_to_rgb * xyz_depth_1;
+        // Project to (u,v) in RGB image
+        const double inv_Z_1 = 1.0 / xyz_rgb_1.z();
+        const int u_rgb_1 = (rgb_fx*xyz_rgb_1.x() + rgb_Tx)*inv_Z_1 + rgb_cx + 0.5;
+        if (u_rgb_1 < 0 || u_rgb_1 >= (int)registered_msg->width)
+          continue;
+        const int v_rgb_1 = (rgb_fy*xyz_rgb_1.y() + rgb_Ty)*inv_Z_1 + rgb_cy + 0.5;
+        if (v_rgb_1 < 0 || v_rgb_1 >= (int)registered_msg->height)
+          continue;
+
+        // TODO(lucasw) this is identical to above except adding 0.5 instead of subtracting
         xyz_depth_2 << ((u+0.5f - depth_cx)*depth - depth_Tx) * inv_depth_fx,
                        ((v+0.5f - depth_cy)*depth - depth_Ty) * inv_depth_fy,
                        depth,
                        1;
-
         // Transform to RGB camera frame
-        Eigen::Vector4d xyz_rgb_1 = depth_to_rgb * xyz_depth_1;
         Eigen::Vector4d xyz_rgb_2 = depth_to_rgb * xyz_depth_2;
-
         // Project to (u,v) in RGB image
-        double inv_Z = 1.0 / xyz_rgb_1.z();
-        int u_rgb_1 = (rgb_fx*xyz_rgb_1.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb_1 = (rgb_fy*xyz_rgb_1.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
-        inv_Z = 1.0 / xyz_rgb_2.z();
-        int u_rgb_2 = (rgb_fx*xyz_rgb_2.x() + rgb_Tx)*inv_Z + rgb_cx + 0.5;
-        int v_rgb_2 = (rgb_fy*xyz_rgb_2.y() + rgb_Ty)*inv_Z + rgb_cy + 0.5;
-
-        if (u_rgb_1 < 0 || u_rgb_2 >= (int)registered_msg->width ||
-            v_rgb_1 < 0 || v_rgb_2 >= (int)registered_msg->height)
+        const double inv_Z_2 = 1.0 / xyz_rgb_2.z();
+        const int u_rgb_2 = (rgb_fx*xyz_rgb_2.x() + rgb_Tx)*inv_Z_2 + rgb_cx + 0.5;
+        if (u_rgb_2 < 0 || u_rgb_2 >= (int)registered_msg->width)
+          continue;
+        const int v_rgb_2 = (rgb_fy*xyz_rgb_2.y() + rgb_Ty)*inv_Z_2 + rgb_cy + 0.5;
+        if (v_rgb_2 < 0 || v_rgb_2 >= (int)registered_msg->height)
           continue;
 
+        // fill in the square defined by uv range
+        const T new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
         for (int nv=v_rgb_1; nv<=v_rgb_2; ++nv)
         {
           for (int nu=u_rgb_1; nu<=u_rgb_2; ++nu)
           {
             T& reg_depth = registered_data[nv*registered_msg->width + nu];
-            T  new_depth = DepthTraits<T>::fromMeters(0.5*(xyz_rgb_1.z()+xyz_rgb_2.z()));
             // Validity and Z-buffer checks
             if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth)
               reg_depth = new_depth;

--- a/depth_image_proc/test/test_register.py
+++ b/depth_image_proc/test/test_register.py
@@ -65,7 +65,6 @@ class TestRegister(unittest.TestCase):
         rospy.loginfo(depth)
 
         depth_msg = self.cv_bridge.cv2_to_imgmsg(depth, "32FC1")
-        ci_msg.header.stamp = rospy.Time.now()
         rgb_ci_msg = copy.deepcopy(ci_msg)
         rgb_ci_msg.header.frame_id = "station2"
         depth_msg.header = ci_msg.header
@@ -87,6 +86,10 @@ class TestRegister(unittest.TestCase):
         self.count = 0
         rospy.loginfo("publishing depth and ci, wait for callbacks")
         for i in range(4):
+            stamp = rospy.Time.now()
+            ci_msg.header.stamp = stamp
+            rgb_ci_msg.header.stamp = stamp
+            depth_msg.header.stamp = stamp
             self.depth_image_pub.publish(depth_msg)
             self.depth_ci_pub.publish(ci_msg)
             self.rgb_ci_pub.publish(rgb_ci_msg)

--- a/depth_image_proc/test/test_register.py
+++ b/depth_image_proc/test/test_register.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+import copy
+import unittest
+
+import numpy as np
+import rospy
+import rostest
+from cv_bridge import CvBridge
+from sensor_msgs.msg import CameraInfo
+from sensor_msgs.msg import Image
+
+
+class TestRegister(unittest.TestCase):
+    def test_register(self):
+        # publish a 2x2 float depth image with depths like
+        # [1.0, 2.0], [2.0, 1.0]
+        # publish a camera info with a aov of around 90 degrees
+        # publish two static tfs in the .test file, one shifted
+        # by 1.0 in x from the depth camera_info frame
+        # another by 2.0 in x, and 1.5 in z, with a 90 degree rotation
+        # looking back at those depth points
+        # publish another camera info, in series, have it shift from one frame to the other
+        # subscribe to the depth_image_proc node and verify output
+        # (make numbers come out even with 90 degree aov)
+
+        self.output_depth = rospy.get_param("~output_depth", 1.0)
+        self.expected_depth = rospy.get_param("~expected_depth", 7.0)
+        rospy.loginfo(f"published depth: {self.output_depth}, expected input depth: {self.expected_depth}")
+
+        self.cv_bridge = CvBridge()
+        self.depth_image_pub = rospy.Publisher("depth/image_rect", Image, queue_size=2)
+        self.depth_ci_pub = rospy.Publisher("depth/camera_info", CameraInfo, queue_size=2)
+        self.rgb_ci_pub = rospy.Publisher("rgb/camera_info", CameraInfo, queue_size=2)
+
+        self.received_msg = None
+
+        # TODO(lucasw) use time sync subscriber
+        self.depth_sub = rospy.Subscriber("depth_registered/image_rect", Image, self.depth_callback, queue_size=2)
+        self.ci_sub = rospy.Subscriber("depth_registered/camera_info", CameraInfo, self.ci_callback, queue_size=2)
+
+        ci_msg = CameraInfo()
+        wd = 3
+        ht = 3
+        ci_msg.header.frame_id = "station1"
+        ci_msg.height = ht
+        ci_msg.width = wd
+        ci_msg.distortion_model = "plumb_bob"
+
+        cx = 1.5
+        cy = 1.5
+        fx = 1.5
+        fy = 1.5
+        ci_msg.K = [fx, 0.0, cx,
+                    0.0, fy, cy,
+                    0.0, 0.0, 1.0]
+        ci_msg.R = [1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1]
+        ci_msg.P = [fx, 0.0, cx, 0.0,
+                    0.0, fy, cy, 0.0,
+                    0.0, 0.0, 1.0, 0.0]
+
+        depth = np.ones((ht, wd, 1), np.float32) * self.output_depth
+        rospy.loginfo(depth)
+
+        depth_msg = self.cv_bridge.cv2_to_imgmsg(depth, "32FC1")
+        ci_msg.header.stamp = rospy.Time.now()
+        rgb_ci_msg = copy.deepcopy(ci_msg)
+        rgb_ci_msg.header.frame_id = "station2"
+        depth_msg.header = ci_msg.header
+
+        for i in range(6):
+            rospy.loginfo(f"{i} waiting for register connections...")
+            num_im_sub = self.depth_image_pub.get_num_connections()
+            num_ci_sub = self.depth_ci_pub.get_num_connections()
+            num_rgb_ci_sub = self.rgb_ci_pub.get_num_connections()
+            rospy.sleep(1)
+            if num_im_sub > 0 and num_ci_sub > 0 and num_rgb_ci_sub > 0:
+                break
+
+        self.assertGreater(self.depth_image_pub.get_num_connections(), 0)
+        self.assertGreater(self.depth_ci_pub.get_num_connections(), 0)
+        self.assertGreater(self.rgb_ci_pub.get_num_connections(), 0)
+        rospy.sleep(1.0)
+
+        self.count = 0
+        rospy.loginfo("publishing depth and ci, wait for callbacks")
+        for i in range(4):
+            self.depth_image_pub.publish(depth_msg)
+            self.depth_ci_pub.publish(ci_msg)
+            self.rgb_ci_pub.publish(rgb_ci_msg)
+            rospy.sleep(0.1)
+
+        while i in range(6):
+            if self.count > 1:
+                break
+            rospy.sleep(1)
+        rospy.loginfo("done waiting")
+
+        self.assertIsNotNone(self.received_msg, "no depth message received")
+        registered_depth = self.cv_bridge.imgmsg_to_cv2(self.received_msg, "32FC1")
+        # the edges of the expected 3x3 image may be nans, but the center should be valid
+        valid_depth = registered_depth[1, 1]
+        self.assertAlmostEqual(valid_depth, self.expected_depth, places=1)
+
+    def depth_callback(self, msg):
+        rospy.loginfo("received depth")
+        self.received_msg = msg
+        self.count += 1
+
+    def ci_callback(self, msg):
+        rospy.logdebug("received camera info")
+
+
+if __name__ == "__main__":
+    node_name = 'test_register'
+    rospy.init_node(node_name)
+    # rostest.rosrun("depth_image_proc", node_name, sys.argv)
+    rostest.rosrun("depth_image_proc", node_name, TestRegister)

--- a/depth_image_proc/test/test_register.rviz
+++ b/depth_image_proc/test/test_register.rviz
@@ -1,0 +1,258 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 138
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /input DepthCloud1
+        - /input DepthCloud1/Auto Size1
+      Splitter Ratio: 0.5
+    Tree Height: 952
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: input DepthCloud
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XZ
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        map:
+          Value: true
+        station1:
+          Value: true
+        station2:
+          Value: true
+        station3:
+          Value: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        map:
+          station1:
+            {}
+          station2:
+            {}
+          station3:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Auto Size:
+        Auto Size Factor: 1
+        Value: true
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/DepthCloud
+      Color: 255; 255; 255
+      Color Image Topic: ""
+      Color Transformer: FlatColor
+      Color Transport Hint: raw
+      Decay Time: 0
+      Depth Map Topic: /depth/image_rect
+      Depth Map Transport Hint: raw
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: input DepthCloud
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Value: false
+      Position Transformer: XYZ
+      Queue Size: 5
+      Selectable: true
+      Size (Pixels): 10
+      Style: Points
+      Topic Filter: true
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: jsk_rviz_plugin/CameraInfo
+      Enabled: true
+      Image Topic: ""
+      Name: input CameraInfo
+      Queue Size: 10
+      Topic: /depth/camera_info
+      Unreliable: false
+      Value: true
+      alpha: 0.5
+      color: 85; 255; 255
+      edge color: 138; 226; 52
+      far clip: 1
+      not show side polygons: true
+      show edges: true
+      show polygons: false
+      transport hints: raw
+      use image: false
+    - Alpha: 1
+      Auto Size:
+        Auto Size Factor: 1
+        Value: true
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/DepthCloud
+      Color: 239; 41; 41
+      Color Image Topic: ""
+      Color Transformer: FlatColor
+      Color Transport Hint: raw
+      Decay Time: 0
+      Depth Map Topic: /depth_registered/image_rect
+      Depth Map Transport Hint: raw
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: output DepthCloud
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Value: false
+      Position Transformer: XYZ
+      Queue Size: 5
+      Selectable: true
+      Size (Pixels): 12
+      Style: Points
+      Topic Filter: true
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: jsk_rviz_plugin/CameraInfo
+      Enabled: true
+      Image Topic: ""
+      Name: output CameraInfo
+      Queue Size: 10
+      Topic: /depth_registered/camera_info
+      Unreliable: false
+      Value: true
+      alpha: 0.5
+      color: 85; 255; 255
+      edge color: 138; 226; 52
+      far clip: 1
+      not show side polygons: true
+      show edges: true
+      show polygons: false
+      transport hints: raw
+      use image: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 7.772470474243164
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0.829400897026062
+        Y: -0.3880631923675537
+        Z: 0.5697964429855347
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: -0.12979792058467865
+      Target Frame: <Fixed Frame>
+      Yaw: 4.640459060668945
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1464
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000298000004b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b000000b000fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000b0fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000006e000004b00000018200fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000015f000004b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000006e000004b00000013200fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000008d800000060fc0100000002fb0000000800540069006d00650100000000000008d80000057100fffffffb0000000800540069006d00650100000000000004500000000000000000000004c9000004b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 2264
+  X: 1478
+  Y: 33

--- a/depth_image_proc/test/test_register.test
+++ b/depth_image_proc/test/test_register.test
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="depth" default="1.0" />
+  <arg name="offset" default="10.0" />
+
+  <node name="station1_tf" pkg="tf" type="static_transform_publisher"
+    args="0.0 0.0 0.0 0 0 0 map station1 15"
+    output="screen" />
+
+  <node name="station2_tf" pkg="tf" type="static_transform_publisher"
+    args="0.0 0.0 -$(arg offset) 0 0 0 map station2 15"
+    output="screen" />
+
+  <node name="station3_tf" pkg="tf" type="static_transform_publisher"
+    args="1.5 0.0 1.5 0 -1.5707963 0 map station3 15"
+    output="screen" />
+
+  <node name="nodelet_manager" pkg="nodelet" type="nodelet" args="manager"
+    output="screen" />
+
+  <node name="reprojected_depth_nodelet" pkg="nodelet" type="nodelet"
+    args="load depth_image_proc/register nodelet_manager"
+    output="screen">
+  <!--
+    <remap from="depth/camera_info" to="$(arg depth_camera_info_in)" />
+    <remap from="depth/image_rect" to="$(arg depth_in)" />
+    <remap from="rgb/camera_info" to="$(arg camera_info_in)" />
+
+    <remap from="depth_registered/image_rect" to="$(arg depth_out)" />
+    <remap from="depth_registered/camera_info" to="$(arg depth_camera_info_out)" />
+  -->
+
+    <param name="fill_upsampling_holes" value="true" />
+    <param name="queue_size" value="10" />
+  </node>
+
+  <group ns="depth_registered/image_rect" >
+    <rosparam param="disable_pub_plugins">
+      - 'image_transport/compressed'
+      - 'image_transport/theora'
+      - 'image_transport/compressedDepth'
+    </rosparam>
+    <param name="compressedDepth/png_level" value="1" />
+    <!-- TODO(lucasw) compression takes a lot of cpu, even with png_level all the way down -->
+    <!--
+    -->
+  </group>
+
+  <test test-name="test_register" pkg="depth_image_proc" type="test_register.py">
+    <param name="output_depth" value="$(arg depth)" />
+    <param name="expected_depth" value="$(eval arg('depth') + arg('offset'))" />
+  </test>
+</launch>


### PR DESCRIPTION
Resolves #721

This is without the PR (the rviz CameraInfo plugin looks to not draw lines properly from certain angles)


https://user-images.githubusercontent.com/1334122/149801865-d275bfec-a51d-4a97-941e-8f6c0c83c2da.mp4

This is with the PR applied:

https://user-images.githubusercontent.com/1334122/149801889-8defd1e5-6062-47b2-82a9-c0d6f743c6f9.mp4

Here's another but without the negative z clipping
https://user-images.githubusercontent.com/1334122/149797323-fc6bf43f-3d12-47ba-9d99-fb334f4c220e.mp4

There are still gaps when there is a big angle between the two tf frames or big depth difference between adjacent pixels/points, making assumptions about adjacent points (that they are part of a continuous surface) and doing the whole software triangle rasterization approach could fix that but seems excessive.

I found adding a lookup transform timeout a62174afd357152af57a58502d8c7b205fc5e131 necessary in my test setup (probably in most real world cases `/tf` is way ahead of >megapixel depth images, but here I'm synthesizing 320x240 depth images so few image transport delays) but left it out of this PR, it could go into a different one?

I can adapt the test setup to here if there is interest, but it will bring in a few `<test_depends>`.

Could squash this down to one or two commits but maybe the commit progression makes it easier to review.

There is a really basic unit test, I can add more to it after getting some feedback.