### PR TITLE
Fixed typo in point_cloud_xyz launch file

### DIFF
--- a/depth_image_proc/launch/point_cloud_xyz.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz.launch.py
@@ -60,7 +60,7 @@ def generate_launch_description():
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzNode',
                     name='point_cloud_xyz_node',
-                    remappings=[('image_raw', '/camera/depth/image_rect_raw'),
+                    remappings=[('image_rect', '/camera/depth/image_rect_raw'),
                                 ('camera_info', '/camera/depth/camera_info'),
                                 ('image', '/camera/depth/converted_image')]
                 ),


### PR DESCRIPTION
- Fixed error in point_cloud_xyz example launch file. Changed the topic from `image_raw` to `image_rect`

Addresses https://github.com/ros-perception/image_pipeline/issues/730 