### PR TITLE
Add conversion for YUV422-YUY2 image encoding

### DIFF
--- a/image_proc/src/debayer.cpp
+++ b/image_proc/src/debayer.cpp
@@ -179,7 +179,7 @@ void DebayerNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & raw_ms
     }
 
     pub_color_.publish(color_msg);
-  } else if (raw_msg->encoding == enc::YUV422) {
+  } else if (raw_msg->encoding == enc::YUV422 || raw_msg->encoding == enc::YUV422_YUY2) {
     // Use cv_bridge to convert to BGR8
     sensor_msgs::msg::Image::SharedPtr color_msg;
 


### PR DESCRIPTION
Some webcams use the encoding "YUV422-YUY2". The current code already delegates color space conversion for YUV422 encoded images to cv_bridge. This PR does the same for the -YUY2 variant. CvBridge added support for this in ros-perception/vision_opencv#396.