### PR TITLE
forward container namespace from stereo_image_proc -> image_proc

### DIFF
--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -40,6 +40,8 @@ from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.actions import PushRosNamespace
@@ -215,7 +217,7 @@ def generate_launch_description():
         SetLaunchConfiguration(
             condition=LaunchConfigurationEquals('container', ''),
             name='container',
-            value='stereo_image_proc_container'
+            value='stereo_image_proc_container',
         ),
         GroupAction(
             [
@@ -224,7 +226,15 @@ def generate_launch_description():
                     PythonLaunchDescriptionSource([
                         FindPackageShare('image_proc'), '/launch/image_proc.launch.py'
                     ]),
-                    launch_arguments={'container': LaunchConfiguration('container')}.items()
+                    launch_arguments={
+                        'container': PathJoinSubstitution([
+                            PythonExpression([
+                                '"/".join("',
+                                LaunchConfiguration('ros_namespace'),
+                                '".split("/")[:-1])'
+                            ]),
+                            LaunchConfiguration('container')
+                        ])}.items()
                 ),
             ],
             condition=IfCondition(LaunchConfiguration('launch_image_proc')),
@@ -236,7 +246,15 @@ def generate_launch_description():
                     PythonLaunchDescriptionSource([
                         FindPackageShare('image_proc'), '/launch/image_proc.launch.py'
                     ]),
-                    launch_arguments={'container': LaunchConfiguration('container')}.items()
+                    launch_arguments={
+                        'container': PathJoinSubstitution([
+                            PythonExpression([
+                                '"/".join("',
+                                LaunchConfiguration('ros_namespace'),
+                                '".split("/")[:-1])'
+                            ]),
+                            LaunchConfiguration('container')
+                        ])}.items()
                 ),
             ],
             condition=IfCondition(LaunchConfiguration('launch_image_proc')),

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -40,7 +40,6 @@ from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
@@ -217,7 +216,12 @@ def generate_launch_description():
         SetLaunchConfiguration(
             condition=LaunchConfigurationEquals('container', ''),
             name='container',
-            value='stereo_image_proc_container',
+            value=PythonExpression([
+                '"stereo_image_proc_container"', ' if ',
+                '"', LaunchConfiguration('ros_namespace', default=''), '"',
+                ' == "" else ', '"',
+                LaunchConfiguration('ros_namespace', default=''), '/stereo_image_proc_container"'
+            ]),
         ),
         GroupAction(
             [
@@ -226,15 +230,7 @@ def generate_launch_description():
                     PythonLaunchDescriptionSource([
                         FindPackageShare('image_proc'), '/launch/image_proc.launch.py'
                     ]),
-                    launch_arguments={
-                        'container': PathJoinSubstitution([
-                            PythonExpression([
-                                '"/".join("',
-                                LaunchConfiguration('ros_namespace'),
-                                '".split("/")[:-1])'
-                            ]),
-                            LaunchConfiguration('container')
-                        ])}.items()
+                    launch_arguments={'container': LaunchConfiguration('container')}.items()
                 ),
             ],
             condition=IfCondition(LaunchConfiguration('launch_image_proc')),
@@ -246,15 +242,7 @@ def generate_launch_description():
                     PythonLaunchDescriptionSource([
                         FindPackageShare('image_proc'), '/launch/image_proc.launch.py'
                     ]),
-                    launch_arguments={
-                        'container': PathJoinSubstitution([
-                            PythonExpression([
-                                '"/".join("',
-                                LaunchConfiguration('ros_namespace'),
-                                '".split("/")[:-1])'
-                            ]),
-                            LaunchConfiguration('container')
-                        ])}.items()
+                    launch_arguments={'container': LaunchConfiguration('container')}.items()
                 ),
             ],
             condition=IfCondition(LaunchConfiguration('launch_image_proc')),


### PR DESCRIPTION
In the following launch file, we expect that the debayer and rectify nodes are launched, but because of the `<push-ros-namespace>` tag, they are not. This is because the namespace [is not prepended](https://github.com/ros-perception/image_pipeline/blob/c2136cda98768408772ee975d1154af4301401e2/stereo_image_proc/launch/stereo_image_proc.launch.py#L227) to the container name passed to `image_proc.launch.py`. 

Example launchfile:

```
<launch>
  <group>
    <push-ros-namespace namespace="navcam" />
    <include file="$(find-pkg-share stereo_image_proc)/launch/stereo_image_proc.launch.py" />
  </group>
</launch>
```

This PR uses a `PathJoinSubstitution` with some `PythonExpression`s to prepend the namespace to the container name and has been tested [i.e. tried on my system] for empty & nested namespaces as well.