### PR TITLE
Camera calibration parameter handling for ROS2

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -77,7 +77,7 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode(Node):
     def __init__(self, name, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0,
+                 pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, fisheye_flags = 0,
                  max_chessboard_speed = -1):
         super().__init__(name)
 

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -81,31 +81,14 @@ class CalibrationNode(Node):
                  max_chessboard_speed = -1):
         super().__init__(name)
         
-        left_camera = self.declare_parameter("left_camera", "").get_parameter_value().string_value
-        right_camera = self.declare_parameter("right_camera", "").get_parameter_value().string_value
-        camera = self.declare_parameter("camera", "").get_parameter_value().string_value
-
-        if camera != "":
-            self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                          camera + "/set_camera_info")
-        else:
-            self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                          "camera/set_camera_info")
+        left_camera = self.declare_parameter("left_camera", "left_camera").get_parameter_value().string_value
+        right_camera = self.declare_parameter("right_camera", "right_camera").get_parameter_value().string_value
+        camera = self.declare_parameter("camera", "camera").get_parameter_value().string_value
         
-        if left_camera != "":
-            self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                left_camera + "/set_camera_info")
-        else:
-            self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                "left_camera/set_camera_info")
+        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, camera + "/set_camera_info")
+        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, left_camera + "/set_camera_info")
+        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, right_camera + "/set_camera_info")
         
-        if right_camera != "":
-            self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                    right_camera + "/set_camera_info")
-        else:
-            self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                    "right_camera/set_camera_info")
-
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for cli in [self.set_camera_info_service, self.set_left_camera_info_service, self.set_right_camera_info_service]:

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -80,13 +80,31 @@ class CalibrationNode(Node):
                  pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0, fisheye_flags = 0,
                  max_chessboard_speed = -1):
         super().__init__(name)
+        
+        left_camera = self.declare_parameter("left_camera", "").get_parameter_value().string_value
+        right_camera = self.declare_parameter("right_camera", "").get_parameter_value().string_value
+        camera = self.declare_parameter("camera", "").get_parameter_value().string_value
 
-        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+        if camera != "":
+            self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+                                                          camera + "/set_camera_info")
+        else:
+            self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
                                                           "camera/set_camera_info")
-        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                               "left_camera/set_camera_info")
-        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                "right_camera/set_camera_info")
+        
+        if left_camera != "":
+            self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+                                                                left_camera + "/set_camera_info")
+        else:
+            self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+                                                                "left_camera/set_camera_info")
+        
+        if right_camera != "":
+            self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+                                                                    right_camera + "/set_camera_info")
+        else:
+            self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
+                                                                    "right_camera/set_camera_info")
 
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready

--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -36,12 +36,14 @@ import cv2
 import functools
 import message_filters
 import rclpy
+from rclpy.node import Node
 from camera_calibration.camera_calibrator import OpenCVCalibrationNode
 from camera_calibration.calibrator import ChessboardInfo, Patterns
 from message_filters import ApproximateTimeSynchronizer
 
 
 def main():
+    print("RUNNING CAMERA CALIBRATOR")
     from optparse import OptionParser, OptionGroup
     parser = OptionParser("%prog --size SIZE1 --square SQUARE1 [ --size SIZE2 --square SQUARE2 ]",
                           description=None)
@@ -84,7 +86,14 @@ def main():
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     parser.add_option_group(group)
+    
+    rclpy.init()
+    testnode = Node("test")
+    val = testnode.declare_parameter("left", "")
+    print("LEFT VAL:", val._value)
     options, _ = parser.parse_args(rclpy.utilities.remove_ros_args())
+    
+    
 
     if len(options.size) != len(options.square):
         parser.error("Number of size and square inputs must be the same!")
@@ -140,7 +149,7 @@ def main():
     else:
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
 
-    rclpy.init()
+    
     node = OpenCVCalibrationNode("cameracalibrator", boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags)
     node.spin()

--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -139,7 +139,7 @@ def main():
         checkerboard_flags = 0
     else:
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
-    
+
     rclpy.init()
     node = OpenCVCalibrationNode("cameracalibrator", boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags)

--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -87,10 +87,6 @@ def main():
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     parser.add_option_group(group)
     
-    rclpy.init()
-    testnode = Node("test")
-    val = testnode.declare_parameter("left", "")
-    print("LEFT VAL:", val._value)
     options, _ = parser.parse_args(rclpy.utilities.remove_ros_args())
     
     
@@ -150,6 +146,7 @@ def main():
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
 
     
+    rclpy.init()
     node = OpenCVCalibrationNode("cameracalibrator", boards, options.service_check, sync, calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags)
     node.spin()

--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -36,14 +36,12 @@ import cv2
 import functools
 import message_filters
 import rclpy
-from rclpy.node import Node
 from camera_calibration.camera_calibrator import OpenCVCalibrationNode
 from camera_calibration.calibrator import ChessboardInfo, Patterns
 from message_filters import ApproximateTimeSynchronizer
 
 
 def main():
-    print("RUNNING CAMERA CALIBRATOR")
     from optparse import OptionParser, OptionGroup
     parser = OptionParser("%prog --size SIZE1 --square SQUARE1 [ --size SIZE2 --square SQUARE2 ]",
                           description=None)
@@ -86,10 +84,7 @@ def main():
     group.add_option("--disable_calib_cb_fast_check", action='store_true', default=False,
                      help="uses the CALIB_CB_FAST_CHECK flag for findChessboardCorners")
     parser.add_option_group(group)
-    
     options, _ = parser.parse_args(rclpy.utilities.remove_ros_args())
-    
-    
 
     if len(options.size) != len(options.square):
         parser.error("Number of size and square inputs must be the same!")
@@ -144,7 +139,6 @@ def main():
         checkerboard_flags = 0
     else:
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
-
     
     rclpy.init()
     node = OpenCVCalibrationNode("cameracalibrator", boards, options.service_check, sync, calib_flags, pattern, options.camera_name,


### PR DESCRIPTION
This is a fix for #754.

I was able to run the cameracalibrator with the following command
```
ros2 run camera_calibration cameracalibrator -s 11x8 -q 0.03 --ros-args -r left:=/stereo/left/image_raw --ros-args -p left_camera:=/stereo/left --ros-args -r right:=/stereo/right/image_raw --ros-args -p right_camera:=/stereo/right
```
