### PR TITLE
add python3-opencv to camera calibration dependency

### DIFF
--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -5,7 +5,7 @@
   <version>3.0.0</version>
   <description>
      camera_calibration allows easy calibration of monocular or stereo
-     cameras using a checkerboard calibration target. 
+     cameras using a checkerboard calibration target.
   </description>
 
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
@@ -22,6 +22,7 @@
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>
   <depend>message_filters</depend>
+  <depend>python3-opencv</depend>
   <depend>rclpy</depend>
   <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Running ``ros2 run camera_calibration cameracalibrator`` after installing camera_calibration via ``apt install ros-rolling-camera-calibration`` the following error shows up. This error doesn't show up when building the whole repo because the stereo_image_proc package has ``python3-opencv`` it [listed as a dependency](https://github.com/ros-perception/image_pipeline/blob/55bf2a38c327b829c3da444f963a6c66bfe0598f/stereo_image_proc/package.xml#L39).

```sh
Traceback (most recent call last):
  File "/workspaces/dev_containers_ros2/rolling/rolling-desktop-full/image_pipeline_ws/install/camera_calibration/lib/camera_calibration/cameracalibrator", line 33, in <module>
    sys.exit(load_entry_point('camera-calibration', 'console_scripts', 'cameracalibrator')())
  File "/workspaces/dev_containers_ros2/rolling/rolling-desktop-full/image_pipeline_ws/install/camera_calibration/lib/camera_calibration/cameracalibrator", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspaces/dev_containers_ros2/rolling/rolling-desktop-full/image_pipeline_ws/build/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py", line 35, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
[ros2run]: Process exited with failure 1
```

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>