### PR TITLE
Porting missing changes from ros2 branch to rolling branch

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -93,12 +93,13 @@ class CalibrationNode(Node):
                  max_chessboard_speed = -1, queue_size = 1):
         super().__init__(name)
 
-        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                          "camera/set_camera_info")
-        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                               "left_camera/set_camera_info")
-        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo,
-                                                                "right_camera/set_camera_info")
+        left_camera = self.declare_parameter("left_camera", "left_camera").get_parameter_value().string_value
+        right_camera = self.declare_parameter("right_camera", "right_camera").get_parameter_value().string_value
+        camera = self.declare_parameter("camera", "camera").get_parameter_value().string_value
+
+        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, camera + "/set_camera_info")
+        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, left_camera + "/set_camera_info")
+        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, right_camera + "/set_camera_info")
 
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready

--- a/image_proc/src/debayer.cpp
+++ b/image_proc/src/debayer.cpp
@@ -189,7 +189,9 @@ void DebayerNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & raw_ms
     }
 
     pub_color_.publish(color_msg);
-  } else if (raw_msg->encoding == sensor_msgs::image_encodings::YUV422) {
+  } else if (raw_msg->encoding == sensor_msgs::image_encodings::YUV422 ||
+    raw_msg->encoding == sensor_msgs::image_encodings::YUV422_YUY2)
+  {
     // Use cv_bridge to convert to BGR8
     sensor_msgs::msg::Image::SharedPtr color_msg;
 

--- a/image_proc/src/debayer.cpp
+++ b/image_proc/src/debayer.cpp
@@ -189,7 +189,7 @@ void DebayerNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & raw_ms
     }
 
     pub_color_.publish(color_msg);
-  } else if (raw_msg->encoding == sensor_msgs::image_encodings::YUV422 ||
+  } else if (raw_msg->encoding == sensor_msgs::image_encodings::YUV422 ||  // NOLINT
     raw_msg->encoding == sensor_msgs::image_encodings::YUV422_YUY2)
   {
     // Use cv_bridge to convert to BGR8


### PR DESCRIPTION
Comapring [ros2 to rolling](https://github.com/ros-perception/image_pipeline/compare/rolling...ros2), the following PRs contained the missing changes and are explained below and modified appropriately:

#755 - changes were copied across to rolling branch apart from the ``fisheye_flags`` which was already a constructor parameter for CalibrationNode from another PR
#757 - this PR was a cherry-pick of [a commit](https://github.com/ros-perception/image_pipeline/pull/718) that is already in the rolling branch, **so can be ignored.**
#747- required a slight change due to merge conflict: ``enc::YUV422_YUY2`` to ``sensor_msgs::image_encodings::YUV422_YUY2``