### PR TITLE
Cropping pointcloud before publishing using min/max XYZ values

### DIFF
--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
@@ -79,7 +79,7 @@ class PointCloudXyzrgbNodelet : public nodelet::Nodelet
 
   image_geometry::PinholeCameraModel model_;
 
-  // variables 
+  // range crop 
   double max_x ;
   double max_y ;
   double max_z ;
@@ -112,13 +112,14 @@ void PointCloudXyzrgbNodelet::onInit()
   rgb_it_  .reset( new image_transport::ImageTransport(*rgb_nh_) );
   depth_it_.reset( new image_transport::ImageTransport(depth_nh) );
   
+  // min/max ranges for crop
   private_nh.param("max_x", max_x, std::numeric_limits<double>::infinity());
   private_nh.param("max_y", max_y, std::numeric_limits<double>::infinity());
   private_nh.param("max_z", max_z, std::numeric_limits<double>::infinity());
   private_nh.param("min_x", min_x, -1*std::numeric_limits<double>::infinity());
   private_nh.param("min_y", min_y, -1*std::numeric_limits<double>::infinity());
   private_nh.param("min_z", min_z, -1*std::numeric_limits<double>::infinity());
-
+ 
   // Read parameters
   int queue_size;
   private_nh.param("queue_size", queue_size, 5);
@@ -355,6 +356,7 @@ void PointCloudXyzrgbNodelet::convert(const sensor_msgs::ImageConstPtr& depth_ms
       }
       else
       {
+        // test if the point is in the XYZ range
         if ( 
             ( (u - center_x) * depth * constant_x ) < max_x &&
             ( (v - center_y) * depth * constant_y ) < max_y &&

--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
@@ -385,6 +385,7 @@ namespace depth_image_proc {
 	    {
 		T depth = depth_row[u];
 
+
 		// Missing points denoted by NaNs
 		if (!DepthTraits<T>::valid(depth))
 		{

--- a/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/nodelets/point_cloud_xyzrgb_radial.cpp
@@ -83,6 +83,14 @@ namespace depth_image_proc {
 	int width_;
 	int height_;
 
+	// range crop 
+	double max_x ;
+	double max_y ;
+	double max_z ;
+	double min_x ;
+	double min_y ;
+	double min_z ;
+
 	cv::Mat transform_;
         image_geometry::PinholeCameraModel model_;
 	
@@ -163,6 +171,15 @@ namespace depth_image_proc {
 	bool use_exact_sync;
 	private_nh.param("exact_sync", use_exact_sync, false);
 
+	// min/max ranges for crop
+	private_nh.param("max_x", max_x, std::numeric_limits<double>::infinity());
+	private_nh.param("max_y", max_y, std::numeric_limits<double>::infinity());
+	private_nh.param("max_z", max_z, std::numeric_limits<double>::infinity());
+	private_nh.param("min_x", min_x, -1*std::numeric_limits<double>::infinity());
+	private_nh.param("min_y", min_y, -1*std::numeric_limits<double>::infinity());
+	private_nh.param("min_z", min_z, -1*std::numeric_limits<double>::infinity());
+	
+	
 	// Synchronize inputs. Topic subscriptions happen on demand in the connection callback.
 	if(use_exact_sync) {
   	  exact_sync_.reset( new ExactSynchronizer(ExactSyncPolicy(queue_size_), sub_depth_, sub_rgb_, sub_info_) );
@@ -393,10 +410,27 @@ namespace depth_image_proc {
 		    continue;
 		}
 		const cv::Vec3f &cvPoint = transform_.at<cv::Vec3f>(u,v) * DepthTraits<T>::toMeters(depth);
-		// Fill in XYZ
-		*iter_x = cvPoint(0);
-		*iter_y = cvPoint(1);
-		*iter_z = cvPoint(2);
+		// test if the point is in the XYZ range
+		if ( 
+            ( cvPoint(0) ) < max_x &&
+            ( cvPoint(1) ) < max_y &&
+            ( cvPoint(2) ) < max_z && 
+            ( cvPoint(0) ) > min_x &&
+            ( cvPoint(1) ) > min_y &&
+            ( cvPoint(2) ) > min_z 
+		)
+		{
+			// Fill in XYZ
+			*iter_x = cvPoint(0);
+			*iter_y = cvPoint(1);
+			*iter_z = cvPoint(2);
+		}
+		else
+		{
+			*iter_x = *iter_y = *iter_z = bad_point;
+		    continue;
+		}
+
 	    }
 	}
     }


### PR DESCRIPTION
A use case would be to crop the pointclouds after certain depth. 

If min/max XYZ are not provided as params, their default values are Inf/-Inf. 

