### PR TITLE
fix calibration service topics and cleanup

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -106,16 +106,19 @@ class CalibrationNode(Node):
         self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, right_camera + "/set_camera_info")
 
         if service_check:
+            available = False
             # assume any non-default service names have been set.  Wait for the service to become ready
             for cli in [self.set_camera_info_service, self.set_left_camera_info_service, self.set_right_camera_info_service]:
                 print("Waiting for service", cli.srv_name, "...")
                 # check all services so they are ready.
-                try:
-                    cli.wait_for_service(timeout_sec=5)
+                if cli.wait_for_service(timeout_sec=1):
+                    available = True
                     print("OK")
-                except Exception as e:
-                    print("Service not found: %s".format(e))
-                    rclpy.shutdown()
+                else:
+                    print(f"Service {cli.srv_name} not found.")
+
+            if not available:
+                raise RuntimeError("no camera service available")
 
         self._boards = boards
         self._calib_flags = flags

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -86,7 +86,7 @@ class ConsumerThread(threading.Thread):
         self.function = function
 
     def run(self):
-        while True:
+        while rclpy.ok():
             m = self.queue.get()
             self.function(m)
 
@@ -259,10 +259,9 @@ class OpenCVCalibrationNode(CalibrationNode):
 
     def spin(self):
         sth = SpinThread(self)
-        sth.setDaemon(True)
         sth.start()
 
-        while True:
+        while rclpy.ok():
             if self.queue_display.qsize() > 0:
                 self.image = self.queue_display.get()
                 cv2.imshow("display", self.image)
@@ -270,7 +269,7 @@ class OpenCVCalibrationNode(CalibrationNode):
                 time.sleep(0.1)
             k = cv2.waitKey(6) & 0xFF
             if k in [27, ord('q')]:
-                rclpy.shutdown()
+                return
             elif k == ord('s') and self.image is not None:
                 self.screendump(self.image)
 

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -108,9 +108,6 @@ class CalibrationNode(Node):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for cli in [self.set_camera_info_service, self.set_left_camera_info_service, self.set_right_camera_info_service]:
-                #remapped = rclpy.remap_name(svcname)
-                #if remapped != svcname:
-                #fullservicename = "%s/set_camera_info" % remapped
                 print("Waiting for service", cli.srv_name, "...")
                 # check all services so they are ready.
                 try:

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -97,13 +97,9 @@ class CalibrationNode(Node):
                  max_chessboard_speed = -1, queue_size = 1):
         super().__init__(name)
 
-        left_camera = self.declare_parameter("left_camera", "left_camera").get_parameter_value().string_value
-        right_camera = self.declare_parameter("right_camera", "right_camera").get_parameter_value().string_value
-        camera = self.declare_parameter("camera", "camera").get_parameter_value().string_value
-
-        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, camera + "/set_camera_info")
-        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, left_camera + "/set_camera_info")
-        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, right_camera + "/set_camera_info")
+        self.set_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, "camera/set_camera_info")
+        self.set_left_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, "left_camera/set_camera_info")
+        self.set_right_camera_info_service = self.create_client(sensor_msgs.srv.SetCameraInfo, "right_camera/set_camera_info")
 
         if service_check:
             available = False

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -317,9 +317,6 @@ class OpenCVCalibrationNode(CalibrationNode):
 
         self.c.set_cammodel( CAMERA_MODEL.PINHOLE if model_select_val < 0.5 else CAMERA_MODEL.FISHEYE)
 
-    def on_model_change(self, model_select_val):
-        self.c.set_cammodel( CAMERA_MODEL.PINHOLE if model_select_val < 0.5 else CAMERA_MODEL.FISHEYE)
-
     def on_scale(self, scalevalue):
         if self.c.calibrated:
             self.c.set_alpha(scalevalue / 100.0)

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -190,10 +190,8 @@ class CalibrationNode(Node):
 
 
     def check_set_camera_info(self, response):
-        if response.done():
-            if response.result() is not None:
-                if response.result().success:
-                    return True
+        if response.success:
+            return True
 
         for i in range(10):
             print("!" * 80)
@@ -215,14 +213,14 @@ class CalibrationNode(Node):
         rv = True
         if self.c.is_mono:
             req.camera_info = info
-            response = self.set_camera_info_service.call_async(req)
+            response = self.set_camera_info_service.call(req)
             rv = self.check_set_camera_info(response)
         else:
             req.camera_info = info[0]
-            response = self.set_left_camera_info_service.call_async(req)
+            response = self.set_left_camera_info_service.call(req)
             rv = rv and self.check_set_camera_info(response)
             req.camera_info = info[1]
-            response = self.set_right_camera_info_service.call_async(req)
+            response = self.set_right_camera_info_service.call(req)
             rv = rv and self.check_set_camera_info(response)
         return rv
 

--- a/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/src/camera_calibration/nodes/cameracalibrator.py
@@ -224,6 +224,7 @@ def main():
                                  checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
                                  queue_size=options.queue_size)
     node.spin()
+    rclpy.shutdown()
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This fixes some issues with checking and calling the `set_camera_info` service, so that the `cameracalibrator` node can be used to set the calibration for a camera, e.g. via
```sh
ros2 run camera_calibration cameracalibrator --size 6x8 --square 0.026 --ros-args --remap /camera/set_camera_info:=/set_camera_info --remap /image:=/camera/image_raw
```