### PR TITLE
added more aruco dicts, fixed aruco linerror bug

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -72,10 +72,22 @@ class ChessboardInfo():
         if pattern=="charuco":
             self.aruco_dict = cv2.aruco.getPredefinedDictionary({
                 "aruco_orig" : cv2.aruco.DICT_ARUCO_ORIGINAL,
+                "4x4_50"    : cv2.aruco.DICT_4X4_50,
+                "4x4_100"    : cv2.aruco.DICT_4X4_100,
                 "4x4_250"    : cv2.aruco.DICT_4X4_250,
+                "4x4_1000"   : cv2.aruco.DICT_4X4_1000,
+                "5x5_50"    : cv2.aruco.DICT_5X5_50,
+                "5x5_100"    : cv2.aruco.DICT_5X5_100,
                 "5x5_250"    : cv2.aruco.DICT_5X5_250,
-                "6x6_250"    : cv2.aruco.DICT_6X6_250,
-                "7x7_250"    : cv2.aruco.DICT_7X7_250}[aruco_dict])
+                "5x5_1000"    : cv2.aruco.DICT_5X5_1000,
+                "6x6_50"    : cv2.aruco.DICT_6x6_50,
+                "6x6_100"    : cv2.aruco.DICT_6x6_100,
+                "6x6_250"    : cv2.aruco.DICT_6x6_250,
+                "6x6_1000"    : cv2.aruco.DICT_6x6_1000,
+                "7x7_50"    : cv2.aruco.DICT_7x7_50,
+                "7x7_100"    : cv2.aruco.DICT_7x7_100,
+                "7x7_250"    : cv2.aruco.DICT_7x7_250,
+                "7x7_1000"    : cv2.aruco.DICT_7x7_1000}[aruco_dict])
             self.charuco_board = cv2.aruco.CharucoBoard_create(self.n_cols, self.n_rows, self.dim, self.marker_size,
                     self.aruco_dict)
 

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -339,7 +339,7 @@ class OpenCVCalibrationNode(CalibrationNode):
         else:
             self.putText(display, "lin.", (width, self.y(0)))
             linerror = drawable.linear_error
-            if linerror < 0:
+            if linerror is None or linerror < 0:
                 msg = "?"
             else:
                 msg = "%.2f" % linerror


### PR DESCRIPTION
Just found I needed a different aruco library, so I enumerated the rest of the standard ones. Also, after calibration if it doesn't find a linerror it would return a None, so now it catches that case. Tested with the 4x4_1000 dictionary