### PR TITLE
Exception Handling for stereo cameraChecker.py 

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -187,14 +187,15 @@ class CameraCheckerNode:
         (lmsg, lcmsg, rmsg, rcmsg) = msg
         lgray = self.mkgray(lmsg)
         rgray = self.mkgray(rmsg)
-
-        L, _ = self.image_corners(lgray)
-        R, _ = self.image_corners(rgray)
-        if L is not None and R is not None:
+        
+        try:
+            L, _ = self.image_corners(lgray)
+            R, _ = self.image_corners(rgray)
+        
             epipolar = self.sc.epipolar_error(L, R)
 
             dimension = self.sc.chessboard_size(L, R, self.board, msg=(lcmsg, rcmsg))
-
             print("epipolar error: %f pixels   dimension: %f m" % (epipolar, dimension))
-        else:
+
+        except TypeError:
             print("no chessboard")


### PR DESCRIPTION
When there's no board visible in images TypeError Exception is thrown such as Below:

```Exception in thread Thread-6:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/ros/noetic/lib/python3/dist-packages/camera_calibration/camera_checker.py", line 77, in run
    self.function(m)
  File "/opt/ros/noetic/lib/python3/dist-packages/camera_calibration/camera_checker.py", line 191, in handle_stereo
    L, _ = self.image_corners(lgray)
TypeError: cannot unpack non-iterable NoneType object
```
changing `if else` to `try except` is quick and easy fix 
