### PR TITLE
Fixing thrown Exception in camerachecker.py

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_checker.py
+++ b/camera_calibration/src/camera_calibration/camera_checker.py
@@ -149,7 +149,7 @@ class CameraCheckerNode:
         if ok:
             return corners, ids
         else:
-            return None
+            return None, None
 
     def handle_monocular(self, msg):
 


### PR DESCRIPTION
When there's no board visible in images TypeError Exception is thrown such as Below:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/ros/noetic/lib/python3/dist-packages/camera_calibration/camera_checker.py", line 77, in run
    self.function(m)
  File "/opt/ros/noetic/lib/python3/dist-packages/camera_calibration/camera_checker.py", line 191, in handle_stereo
    L, _ = self.image_corners(lgray)
TypeError: cannot unpack non-iterable NoneType object
```

changing `None` to `None,None` in else statement of `image_corners` so false condition also return a tuple