### PR TITLE
feat: image_saver reports an error on file save

### DIFF
--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -142,8 +142,11 @@ bool ImageSaverNode::saveImage(
     }
 
     if (save_all_image_ || save_image_service_) {
-      cv::imwrite(filename, image);
-      RCLCPP_INFO(this->get_logger(), "Saved image %s", filename.c_str());
+      if (cv::imwrite(filename, image)) {
+        RCLCPP_INFO(this->get_logger(), "Saved image %s", filename.c_str());
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Failed to save image to path %s", filename.c_str());
+      }
 
       save_image_service_ = false;
     } else {


### PR DESCRIPTION
This makes it more obvious if the `image_saver` is unable to save the file so you know to track down an issue.

Can this be back ported to humble as well please?