### PR TITLE
[Humble] Use the same QoS profiles as publishers in image_proc

### DIFF
--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -36,6 +36,8 @@
 #include <string>
 
 #include <image_proc/crop_decimate.hpp>
+#include <image_proc/utils.hpp>
+
 #include <opencv2/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/image_encodings.hpp>
@@ -106,6 +108,8 @@ void decimate(const cv::Mat & src, cv::Mat & dst, int decimation_x, int decimati
 CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
 : Node("CropNonZeroNode", options)
 {
+  auto qos_profile = getTopicQosProfile(this, "image_raw");
+
   queue_size_ = this->declare_parameter("queue_size", 5);
   target_frame_id_ = this->declare_parameter("target_frame_id", std::string());
 
@@ -123,11 +127,11 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
   int interpolation = this->declare_parameter("interpolation", 0);
   interpolation_ = static_cast<CropDecimateModes>(interpolation);
 
-  pub_ = image_transport::create_camera_publisher(this, "out/image_raw");
+  pub_ = image_transport::create_camera_publisher(this, "out/image_raw", qos_profile);
   sub_ = image_transport::create_camera_subscription(
     this, "in/image_raw", std::bind(
       &CropDecimateNode::imageCb, this,
-      std::placeholders::_1, std::placeholders::_2), "raw");
+      std::placeholders::_1, std::placeholders::_2), "raw", qos_profile);
 }
 
 void CropDecimateNode::imageCb(

--- a/image_proc/src/crop_non_zero.cpp
+++ b/image_proc/src/crop_non_zero.cpp
@@ -38,6 +38,8 @@
 #include "cv_bridge/cv_bridge.h"
 
 #include <image_proc/crop_non_zero.hpp>
+#include <image_proc/utils.hpp>
+
 #include <image_transport/image_transport.hpp>
 #include <opencv2/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -50,13 +52,14 @@ namespace image_proc
 CropNonZeroNode::CropNonZeroNode(const rclcpp::NodeOptions & options)
 : Node("CropNonZeroNode", options)
 {
-  pub_ = image_transport::create_publisher(this, "image");
+  auto qos_profile = getTopicQosProfile(this, "image_raw");
+  pub_ = image_transport::create_publisher(this, "image", qos_profile);
   RCLCPP_INFO(this->get_logger(), "subscribe: %s", "image_raw");
   sub_raw_ = image_transport::create_subscription(
     this, "image_raw",
     std::bind(
       &CropNonZeroNode::imageCb,
-      this, std::placeholders::_1), "raw");
+      this, std::placeholders::_1), "raw", qos_profile);
 }
 
 void CropNonZeroNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & raw_msg)

--- a/image_proc/src/debayer.cpp
+++ b/image_proc/src/debayer.cpp
@@ -38,6 +38,7 @@
 #include "cv_bridge/cv_bridge.h"
 
 #include <image_proc/debayer.hpp>
+#include <image_proc/utils.hpp>
 // Until merged into OpenCV
 #include <image_proc/edge_aware.hpp>
 #include <image_transport/image_transport.hpp>
@@ -51,14 +52,15 @@ namespace image_proc
 DebayerNode::DebayerNode(const rclcpp::NodeOptions & options)
 : Node("DebayerNode", options)
 {
+  auto qos_profile = getTopicQosProfile(this, "image_raw");
   sub_raw_ = image_transport::create_subscription(
     this, "image_raw",
     std::bind(
       &DebayerNode::imageCb, this,
-      std::placeholders::_1), "raw");
+      std::placeholders::_1), "raw", qos_profile);
 
-  pub_mono_ = image_transport::create_publisher(this, "image_mono");
-  pub_color_ = image_transport::create_publisher(this, "image_color");
+  pub_mono_ = image_transport::create_publisher(this, "image_mono", qos_profile);
+  pub_color_ = image_transport::create_publisher(this, "image_color", qos_profile);
   debayer_ = this->declare_parameter("debayer", 3);
 }
 

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -37,6 +37,8 @@
 #include "tracetools_image_pipeline/tracetools.h"
 
 #include <image_proc/rectify.hpp>
+#include <image_proc/utils.hpp>
+
 #include <image_transport/image_transport.hpp>
 #include <opencv2/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -49,14 +51,15 @@ namespace image_proc
 RectifyNode::RectifyNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("RectifyNode", options)
 {
+  auto qos_profile = getTopicQosProfile(this, "image");
   queue_size_ = this->declare_parameter("queue_size", 5);
   interpolation = this->declare_parameter("interpolation", 1);
   pub_rect_ = image_transport::create_publisher(this, "image_rect");
-  subscribeToCamera();
+  subscribeToCamera(qos_profile);
 }
 
 // Handles (un)subscribing when clients (un)subscribe
-void RectifyNode::subscribeToCamera()
+void RectifyNode::subscribeToCamera(const rmw_qos_profile_t & qos_profile)
 {
   std::lock_guard<std::mutex> lock(connect_mutex_);
 
@@ -71,7 +74,7 @@ void RectifyNode::subscribeToCamera()
   sub_camera_ = image_transport::create_camera_subscription(
     this, "image", std::bind(
       &RectifyNode::imageCb,
-      this, std::placeholders::_1, std::placeholders::_2), "raw");
+      this, std::placeholders::_1, std::placeholders::_2), "raw", qos_profile);
   // }
 }
 

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -37,6 +37,8 @@
 #include "tracetools_image_pipeline/tracetools.h"
 
 #include <image_proc/resize.hpp>
+#include <image_proc/utils.hpp>
+
 #include <image_transport/image_transport.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -49,15 +51,16 @@ namespace image_proc
 ResizeNode::ResizeNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ResizeNode", options)
 {
+  auto qos_profile = getTopicQosProfile(this, "image");
   // Create image pub
-  pub_image_ = image_transport::create_camera_publisher(this, "resize");
+  pub_image_ = image_transport::create_camera_publisher(this, "resize", qos_profile);
   // Create image sub
   sub_image_ = image_transport::create_camera_subscription(
     this, "image",
     std::bind(
       &ResizeNode::imageCb, this,
       std::placeholders::_1,
-      std::placeholders::_2), "raw");
+      std::placeholders::_2), "raw", qos_profile);
 
   interpolation_ = this->declare_parameter("interpolation", 1);
   use_scale_ = this->declare_parameter("use_scale", true);


### PR DESCRIPTION
Currently nodes in `image_proc` work only with default QoS profiles. This change retrieves QoS profiles from topic's publishers and uses the same ones. This allows working with sensor data QoS which is often used for cameras. It also fixes #807.

If approved, I will create analogous PR for `rolling`.