### PR TITLE
[image_nodelet] change destroyWindow() to destroyAllWindows()

### DIFF
--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -306,7 +306,7 @@ void ImageNodelet::windowThread()
   {
   }
 
-  cv::destroyWindow(window_name_);
+  cv::destroyAllWindows();
 
   pub_.shutdown();
 


### PR DESCRIPTION
When image_view window is closed wirh "x" button, `cv::Exception` is thrown and the node cannot successfully be killed: 
```
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.2.0) ../modules/highgui/src/window_gtk.cpp:1260: error: (-215:Assertion failed) found && "Can't destroy non-registered window" in function 'cvDestroyWindow'

[image_view00-5] process has died [pid 3148875, exit code -6, cmd /home/nakane/ros/catkin_ws/devel/lib/image_view/image_view image:=tile_image_2x1/output __name:=image_view00 __log:=/home/nakane/.ros/log/20230517-160130_a69074d6-f480-11ed-9b90-0b32d9e34b63/image_view00-5.log].
```

I replaced `cv::destroyWindow(window_name_)` with `cv::destroyAllWindows()` to avoid destroying windows that no longer exist. 
