### PR TITLE
Fix to allow remapping resize and image topics

### DIFF
--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -108,7 +108,7 @@ void decimate(const cv::Mat & src, cv::Mat & dst, int decimation_x, int decimati
 CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
 : Node("CropNonZeroNode", options)
 {
-  auto qos_profile = getTopicQosProfile(this, "image_raw");
+  auto qos_profile = getTopicQosProfile(this, "in/image_raw");
 
   queue_size_ = this->declare_parameter("queue_size", 5);
   target_frame_id_ = this->declare_parameter("target_frame_id", std::string());

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -51,12 +51,12 @@ namespace image_proc
 ResizeNode::ResizeNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ResizeNode", options)
 {
-  auto qos_profile = getTopicQosProfile(this, "image");
+  auto qos_profile = getTopicQosProfile(this, "image/image_raw");
   // Create image pub
-  pub_image_ = image_transport::create_camera_publisher(this, "resize", qos_profile);
+  pub_image_ = image_transport::create_camera_publisher(this, "resize/image_raw", qos_profile);
   // Create image sub
   sub_image_ = image_transport::create_camera_subscription(
-    this, "image",
+    this, "image/image_raw",
     std::bind(
       &ResizeNode::imageCb, this,
       std::placeholders::_1,


### PR DESCRIPTION
Basically the same as #786 but fixes merge conflicts and minor bug introduced by #814.