### PR TITLE
Loading image_rotate::ImageRotateNode as component

### DIFF
--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -71,7 +71,7 @@ struct ImageRotateConfig
 class ImageRotateNode : public rclcpp::Node
 {
 public:
-  IMAGE_ROTATE_PUBLIC ImageRotateNode();
+  IMAGE_ROTATE_PUBLIC ImageRotateNode(const rclcpp::NodeOptions& options);
 
 private:
   const std::string frameWithDefault(const std::string & frame, const std::string & image_frame);

--- a/image_rotate/src/image_rotate.cpp
+++ b/image_rotate/src/image_rotate.cpp
@@ -46,7 +46,8 @@ int main(int argc, char ** argv)
   }
 
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<image_rotate::ImageRotateNode>();
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<image_rotate::ImageRotateNode>(options);
 
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -69,8 +69,8 @@
 namespace image_rotate
 {
 
-ImageRotateNode::ImageRotateNode()
-: rclcpp::Node("ImageRotateNode")
+ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions& options)
+: rclcpp::Node("ImageRotateNode", options)
 {
   config_.target_frame_id = this->declare_parameter("target_frame_id", std::string(""));
   config_.target_x = this->declare_parameter("target_x", 0.0);
@@ -361,7 +361,7 @@ void ImageRotateNode::onInit()
 }
 }  // namespace image_rotate
 
-#include "class_loader/register_macro.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
 
 // Register the component with class_loader.
-CLASS_LOADER_REGISTER_CLASS(image_rotate::ImageRotateNode, rclcpp::Node)
+RCLCPP_COMPONENTS_REGISTER_NODE(image_rotate::ImageRotateNode)


### PR DESCRIPTION
It seems that on the **ROS 2 branches** (at least for Humble, Galactic and Foxy) the **`image_rotate::ImageRotateNode`** 
is still exported with the `CLASS_LOADER_REGISTER_CLASS` macro:

https://github.com/ros-perception/image_pipeline/blob/975548a97abf5de7cdebfd0c8be6712fe128bcee/image_rotate/src/image_rotate_node.cpp#L364-L367

Similarly to https://github.com/ros-perception/image_pipeline/pull/691 the component is displayed when listing all component types with:

```
$ ros2 component types
...
image_rotate
  image_rotate::ImageRotateNode
...
```

but results in a **runtime error when trying to load it into a `component_container`**

```
$ ros2 run rclcpp_components component_container
$ ros2 component load /ComponentManager image_rotate image_rotate::ImageRotateNode
[INFO] [1685614749.711272077] [ComponentManager]: Load Library: /opt/ros/humble/lib/libimage_rotate.so
[ERROR] [1685614749.744623406] [ComponentManager]: Failed to find class with the requested plugin name 'image_rotate::ImageRotateNode' in the loaded library
```

This pull request fixes this by replacing the `CLASS_LOADER_REGISTER_CLASS` macro with the `RCLCPP_COMPONENTS_REGISTER_NODE` macro and updating `image_rotate::ImageRotateNode`'s constructor to take `const rclcpp::NodeOptions& options` as an argument.