### PR TITLE
fix: change type of epsilon

### DIFF
--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -166,7 +166,7 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
-  bool approx_sync_epsilon = this->declare_parameter("approximate_sync_tolerance_seconds", 0.0);
+  double approx_sync_epsilon = this->declare_parameter("approximate_sync_tolerance_seconds", 0.0);
   this->declare_parameter("use_system_default_qos", false);
 
   // Synchronize callbacks

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -110,7 +110,7 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
   // Declare/read parameters
   int queue_size = this->declare_parameter("queue_size", 5);
   bool approx = this->declare_parameter("approximate_sync", false);
-  bool approx_sync_epsilon = this->declare_parameter("approximate_sync_tolerance_seconds", 0.0);
+  double approx_sync_epsilon = this->declare_parameter("approximate_sync_tolerance_seconds", 0.0);
   this->declare_parameter("use_system_default_qos", false);
   rcl_interfaces::msg::ParameterDescriptor descriptor;
   // TODO(ivanpauno): Confirm if using point cloud padding in `sensor_msgs::msg::PointCloud2`


### PR DESCRIPTION
This PR fixes type of epsilon to prevent the epsilon from always being set to 1 second.