### PR TITLE
Fixed arguments when using the rclcpp_component as a regular node in image_view

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -57,6 +57,7 @@ add_dependencies(disparity_view
 
 ament_auto_add_executable(${PROJECT_NAME}
   src/image_view.cpp
+  src/utilities.cpp
 )
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_nodes

--- a/image_view/src/image_view.cpp
+++ b/image_view/src/image_view.cpp
@@ -46,19 +46,94 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include <rclcpp/rclcpp.hpp>
 
 #include "image_view/image_view_node.hpp"
+#include "utilities.hpp"
 
 int main(int argc, char ** argv)
 {
   using image_view::ImageViewNode;
 
-  rclcpp::init(argc, argv);
+  std::vector<std::string> args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+
+  // remove program name
+  args.erase(args.begin());
+
+  std::string image_transport{"raw"};
+  std::string window_name{"window"};
+  bool gui{true};
+  bool autosize{false};
+  int width{-1};
+  int height{-1};
+  std::string fileformat{"frame%04i.jpg"};
+  int colormap{-1};
+  int min_image_value{0};
+  int max_image_value{0};
+
+  if (image_view::has_option(args, "--image_transport")) {
+    image_transport = image_view::get_option(args, "--image_transport");
+  }
+  if (image_view::has_option(args, "--window_name")) {
+    window_name = image_view::get_option(args, "--window_name");
+  }
+  if (image_view::has_option(args, "--gui")) {
+    std::string result = image_view::get_option(args, "--gui");
+    if (result.size() == 1) {
+      std::istringstream(result) >> gui;
+    } else {
+      std::istringstream(result) >> std::boolalpha >> gui;
+    }
+  }
+  if (image_view::has_option(args, "--autosize")) {
+    std::string result = image_view::get_option(args, "--autosize");
+    if (result.size() == 1) {
+      std::istringstream(result) >> autosize;
+    } else {
+      std::istringstream(result) >> std::boolalpha >> autosize;
+    }
+  }
+  if (image_view::has_option(args, "--width")) {
+    width = std::atoi(image_view::get_option(args, "--width").c_str());
+  }
+  if (image_view::has_option(args, "--height")) {
+    height = std::atoi(image_view::get_option(args, "--height").c_str());
+  }
+  if (image_view::has_option(args, "--fileformat")) {
+    fileformat = image_view::get_option(args, "--fileformat");
+  }
+  if (image_view::has_option(args, "--colormap")) {
+    colormap = std::atoi(image_view::get_option(args, "--colormap").c_str());
+  }
+  if (image_view::has_option(args, "--min_image_value")) {
+    min_image_value = std::atoi(image_view::get_option(args, "--min_image_value").c_str());
+  }
+  if (image_view::has_option(args, "--max_image_value")) {
+    max_image_value = std::atoi(image_view::get_option(args, "--max_image_value").c_str());
+  }
 
   rclcpp::NodeOptions options;
+  // override default parameters with the desired transform
+  options.parameter_overrides(
+  {
+    {"image_transport", image_transport},
+    {"window_name", window_name},
+    {"gui", gui},
+    {"autosize", autosize},
+    {"height", height},
+    {"width", width},
+    {"colormap", colormap},
+    {"min_image_value", min_image_value},
+    {"max_image_value", max_image_value},
+    {"fileformat", fileformat},
+  });
+
   auto iv_node = std::make_shared<ImageViewNode>(options);
 
   rclcpp::spin(iv_node);

--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -122,7 +122,7 @@ ImageViewNode::ImageViewNode(const rclcpp::NodeOptions & options)
     RCLCPP_WARN(
       this->get_logger(), "Topic 'image' has not been remapped! "
       "Typical command-line usage:\n"
-      "\t$ rosrun image_view image_view image:=<image topic> [transport]");
+      "\t$ ros2 run image_view image_view image:=<image topic> --image_transport transport");
   }
 
   // Default window name is the resolved topic name

--- a/image_view/src/utilities.cpp
+++ b/image_view/src/utilities.cpp
@@ -1,0 +1,45 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utilities.hpp"
+
+#include <string>
+#include <vector>
+
+namespace image_view
+{
+std::string get_option(const std::vector<std::string> & args, const std::string & option_name)
+{
+  for (auto it = args.begin(), end = args.end(); it != end; ++it) {
+    if (*it == option_name) {
+      if (it + 1 != end) {
+        return *(it + 1);
+      }
+    }
+  }
+
+  return "";
+}
+
+bool has_option(const std::vector<std::string> & args, const std::string & option_name)
+{
+  for (auto it = args.begin(), end = args.end(); it != end; ++it) {
+    if (*it == option_name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+}  // namespace image_view

--- a/image_view/src/utilities.hpp
+++ b/image_view/src/utilities.hpp
@@ -1,0 +1,35 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILITIES_HPP_
+#define UTILITIES_HPP_
+
+#include <string>
+#include <vector>
+
+namespace image_view
+{
+/// Get the option from a list of arguments
+/// param[in] args List of arguments
+/// param[in] option name to extract
+/// return option value
+std::string get_option(const std::vector<std::string> & args, const std::string & option_name);
+
+/// Is the option available in the list of arguments
+/// param[in] args List of arguments
+/// param[in] option name to extract
+/// return true if the option exists or false otherwise
+bool has_option(const std::vector<std::string> & args, const std::string & option_name);
+}  // namespace image_view
+#endif  // UTILITIES_HPP_


### PR DESCRIPTION
Fixed arguments when using the rclcpp_component as a regular node in image_view

Related with this issue https://github.com/ros-perception/image_pipeline/issues/824

I can also open PRs for the other nodes.