### PR TITLE
fix(foxy): name CAMERA_MODEL is not defined in foxy branch

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -47,6 +47,7 @@ from collections import deque
 from message_filters import ApproximateTimeSynchronizer
 from std_msgs.msg import String
 from std_srvs.srv import Empty
+from .calibrator import CAMERA_MODEL
 
 class SpinThread(threading.Thread):
     """


### PR DESCRIPTION
Fixes https://github.com/ros-perception/image_pipeline/issues/833