### PR TITLE
Allow setting the filename using ROS parameter in image_publisher node

### DIFF
--- a/image_publisher/src/node/image_publisher.cpp
+++ b/image_publisher/src/node/image_publisher.cpp
@@ -38,13 +38,16 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "image_publisher", ros::init_options::AnonymousName);
 
-  if (argc <= 1) {
-    ROS_ERROR("image_publisher requires filename. Typical command-line usage:\n"
-              "\t$ rosrun image_publisher image_publisher <filename>");
-    return 1;
+  if (!ros::param::has("~filename")) {
+    if (argc <= 1) {
+      ROS_ERROR("image_publisher requires filename. Typical command-line usage:\n"
+                "\t$ rosrun image_publisher image_publisher <filename>");
+      return 1;
+    }
+
+    ros::param::set("~filename", argv[1]);
   }
 
-  ros::param::set("~filename", argv[1]);
   nodelet::Loader manager(false);
   nodelet::M_string remappings;
   nodelet::V_string my_argv(argv + 1, argv + argc);


### PR DESCRIPTION
Current implementation of `image_publisher` node doesn’t allow the user to set the published image file name using the ROS parameter (`~filename`). It just exits with the `image_publisher requires filename` error.

But using parameter is very natural for ROS, and it's useful as well: you can set filename in a launch file using `command` attribute of `param` tag (and other features of parameters). Like this:

```xml
<node pkg="image_publisher" type="image_publisher" name="image_publisher">
    <param name="filename" command="<call some script to determine file name>"/>
</node>
```

For my project, I need a more complex logic to determine the name of the published file, and I was surprised this doesn't work (non-obvious from the documentation).