### PR TITLE
[camera_calibration] fix/feat: enable to select range policy for 16 bit images

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -132,6 +132,9 @@ def main():
     group.add_option("--max-chessboard-speed", type="float", default=-1.0,
                      help="Do not use samples where the calibration pattern is moving faster \
                      than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
+    parser.add_option("-r", "--range-policy",
+                     type="string", default="upper",
+                     help="For 16 bit images, the policy to use for determining the range of pixel values to use for thresholding. Choose from 'upper', 'dynamic', or 'legacy'.")
 
     parser.add_option_group(group)
 
@@ -219,10 +222,13 @@ def main():
     else:
         checkerboard_flags = cv2.CALIB_CB_FAST_CHECK
 
+    range_policy = options.range_policy
+    assert range_policy in ['upper', 'dynamic', 'legacy'], "Invalid range policy: %s" % range_policy
+
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, fisheye_calib_flags, pattern, options.camera_name,
                                  checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
-                                 queue_size=options.queue_size)
+                                 queue_size=options.queue_size, range_policy=range_policy)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -109,8 +109,8 @@ class ConsumerThread(threading.Thread):
 
 class CalibrationNode:
     def __init__(self, boards, service_check = True, synchronizer = message_filters.TimeSynchronizer, flags = 0,
-                fisheye_flags = 0, pattern=Patterns.Chessboard, camera_name='', checkerboard_flags = 0,
-                max_chessboard_speed = -1, queue_size = 1):
+                 fisheye_flags = 0, pattern=Patterns.Chessboard, camera_name = '', checkerboard_flags = 0,
+                 max_chessboard_speed = -1, queue_size = 1, range_policy = "upper"):
         if service_check:
             # assume any non-default service names have been set.  Wait for the service to become ready
             for svcname in ["camera", "left_camera", "right_camera"]:
@@ -132,6 +132,8 @@ class CalibrationNode:
         self._pattern = pattern
         self._camera_name = camera_name
         self._max_chessboard_speed = max_chessboard_speed
+        self._range_policy = range_policy
+
         lsub = message_filters.Subscriber('left', sensor_msgs.msg.Image)
         rsub = message_filters.Subscriber('right', sensor_msgs.msg.Image)
         ts = synchronizer([lsub, rsub], 4)
@@ -178,11 +180,11 @@ class CalibrationNode:
             if self._camera_name:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern, name=self._camera_name,
                                         checkerboard_flags=self._checkerboard_flags,
-                                        max_chessboard_speed = self._max_chessboard_speed)
+                                        max_chessboard_speed=self._max_chessboard_speed, range_policy=self._range_policy)
             else:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern,
                                         checkerboard_flags=self.checkerboard_flags,
-                                        max_chessboard_speed = self._max_chessboard_speed)
+                                        max_chessboard_speed=self._max_chessboard_speed, range_policy=self._range_policy)
 
         # This should just call the MonoCalibrator
         drawable = self.c.handle_msg(msg)
@@ -194,11 +196,11 @@ class CalibrationNode:
             if self._camera_name:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern, name=self._camera_name,
                                           checkerboard_flags=self._checkerboard_flags,
-                                          max_chessboard_speed = self._max_chessboard_speed)
+                                          max_chessboard_speed=self._max_chessboard_speed, range_policy=self._range_policy)
             else:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern,
                                           checkerboard_flags=self._checkerboard_flags,
-                                          max_chessboard_speed = self._max_chessboard_speed)
+                                          max_chessboard_speed=self._max_chessboard_speed, range_policy=self._range_policy)
 
         drawable = self.c.handle_msg(msg)
         self.displaywidth = drawable.lscrib.shape[1] + drawable.rscrib.shape[1]


### PR DESCRIPTION
## feature description
cc. and thanks: @pazeshun, @iory, @tkmtnt7000

This PR enables the selection of a range policy for 16-bit images, offering choices among "upper", "dynamic", and "legacy". Actually, this **fixes a bug (or incompatibility with old device)** introduced by https://github.com/ros-perception/image_pipeline/pull/334, which is described in *background and context* in detail. 

When "upper" is selected, the upper bit is used (as in the current implementation). If "dynamic" is chosen, a dynamic range utilizing the min/max value is adopted. For "legacy", clamping to 255 is applied. 

By the way, for our device (kinect-v1) legacy mode produce most stable for IR calibration.

Dynamic range determination is similar to the one adopted in rviz https://github.com/ros-visualization/rviz/blob/b466cb9d21a78170d9031cbbc7cc5ecc9886af52/src/rviz/image/ros_image_texture.cpp#L115
The below is the screenshot that compares the `cameracalibrator.py`'s output (left) and rviz visualization of mono16 IR image(right), showing the consistency with our implementation and rviz one. 
![Screenshot from 2023-12-06 20-50-59](https://github.com/ros-perception/image_pipeline/assets/38597814/c657ad34-133a-4e1d-8c5d-10af85b2980d)
**cameracalibration.py (left), rviz (right)**

## background and context
I suspect that the reason for the "legacy" method clamping the image to a range of 0-255 is due to older cameras (e.g., Kinect v1) producing relatively dark IR images. However, more recent cameras may use brighter IR images, which can result in "white-out" issues, as pointed out in this pull request https://github.com/ros-perception/image_pipeline/pull/334. 
However, that PR make it incompatible with less-bright IR cameras. The original motivation of this PR is make this re-compatible with less-bright IR cameras. We still use kinect-v1 and tried to calibrate the IR camera of it following the instruction in https://wiki.ros.org/openni_launch/Tutorials/IntrinsicCalibration but encoutnered black-outed image on the GUI window produced by `rosrun camera_calibration cameracalibrator.py`. 

After this PR, by setting the range policy to either of "dynamic" or "legacy", the calibration node start to work fine with kinect V1. 

Implementing dynamic range determination only might be the cleanest approach, but maintaining previous behaviors for backward compatibility is also reasonable. Also, just I dont have enough resource to check the behavior to all the cameras is the part of the reason to leave the previous implementation.

## Behavior check with kinect v1 IR image. 
```
rosrun camera_calibration cameracalibrator.py image:=/kinect_head/ir/image_raw camera:=/kinect_head/ir --size 5x4 --square 0.0245 -r upper 
```

with `upper` (identical to current implementation and what we got stuck with)
![Screenshot from 2023-12-06 20-35-12](https://github.com/ros-perception/image_pipeline/assets/38597814/bfcb1545-21a1-4b14-8f2b-074f7eeb19c0)

with `legacy`:
```
rosrun camera_calibration cameracalibrator.py image:=/kinect_head/ir/image_raw camera:=/kinect_head/ir --size 5x4 --square 0.0245 -r legacy
```
![Screenshot from 2023-12-06 20-32-53](https://github.com/ros-perception/image_pipeline/assets/38597814/964219e3-c5e9-485f-b36e-3c75158df4cb)

with `dynamic`:
```
rosrun camera_calibration cameracalibrator.py image:=/kinect_head/ir/image_raw camera:=/kinect_head/ir --size 5x4 --square 0.0245 -r dynamic
```
![Screenshot from 2023-12-06 20-34-07](https://github.com/ros-perception/image_pipeline/assets/38597814/0b6760c1-764c-4c50-8c2d-b1f7813a3fc1)

## behavior check with kinect v1 RGB image
Although RGB image is not the direct target of this PR, but I tested by running 
```
rosrun camera_calibration cameracalibrator.py --size 6x7 --square 0.108 camera:=/kinect_head/rgb image:=/kinect_head/rgb/image_raw
```
and confirmed that calibration procedure performed successfully, without any syntax error stuff. 

## mypy check
Running mypy version 1.7.1 (not for type check but for syntax check) and confirmed that no related error. (only found import-untyped and no-redef)
```
h-ishida@azarashi:~/planning_ws/src/image_pipeline/camera_calibration$ mypy src/
src/camera_calibration/calibrator.py:37: error: Skipping analyzing "cv_bridge": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/calibrator.py:38: error: Skipping analyzing "image_geometry": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/calibrator.py:43: error: Skipping analyzing "sensor_msgs.msg": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/calibrator.py:43: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/camera_calibration/calibrator.py:43: error: Skipping analyzing "sensor_msgs": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:36: error: Skipping analyzing "cv_bridge": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:38: error: Skipping analyzing "message_filters": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:40: error: Skipping analyzing "rospy": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:41: error: Skipping analyzing "sensor_msgs.msg": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:41: error: Skipping analyzing "sensor_msgs": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:42: error: Skipping analyzing "sensor_msgs.srv": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_checker.py:51: error: Cannot find implementation or library stub for module named "Queue"  [import-not-found]
src/camera_calibration/camera_checker.py:51: error: Name "Queue" already defined (possibly by an import)  [no-redef]
src/camera_calibration/camera_calibrator.py:36: error: Skipping analyzing "message_filters": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_calibrator.py:39: error: Skipping analyzing "rospy": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_calibrator.py:40: error: Skipping analyzing "sensor_msgs.msg": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_calibrator.py:40: error: Skipping analyzing "sensor_msgs": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_calibrator.py:41: error: Skipping analyzing "sensor_msgs.srv": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/camera_calibration/camera_calibrator.py:48: error: Cannot find implementation or library stub for module named "Queue"  [import-not-found]
src/camera_calibration/camera_calibrator.py:48: error: Name "Queue" already defined (possibly by an import)  [no-redef]
Found 19 errors in 3 files (checked 4 source files)
h-ishida@azarashi:~/planning_ws/src/image_pipeline/camera_calibration$ mypy --version
mypy 1.7.1 (compiled: yes)
```
