### PR TITLE
[camera_calibration] fix typo self.checkerboard_flags to self._checkerboard_flags

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -181,7 +181,7 @@ class CalibrationNode:
                                         max_chessboard_speed = self._max_chessboard_speed)
             else:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern,
-                                        checkerboard_flags=self.checkerboard_flags,
+                                        checkerboard_flags=self._checkerboard_flags,
                                         max_chessboard_speed = self._max_chessboard_speed)
 
         # This should just call the MonoCalibrator


### PR DESCRIPTION
This PR fixes an obvious bug.

The attributename is  `_cehckerboard_flag`.
https://github.com/ros-perception/image_pipeline/blob/948847514311772cf1d0fd84ef8bebbac94c940f/camera_calibration/src/camera_calibration/camera_calibrator.py#L131

So, `self.checkerboard_flags` is a typo