### PR TITLE
properly remap compressed topics

### DIFF
--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -52,7 +52,11 @@ using namespace std::chrono_literals;
 ImagePublisher::ImagePublisher(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ImagePublisher", options)
 {
-  pub_ = image_transport::create_camera_publisher(this, "image_raw");
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string topic_name = node_base->resolve_topic_or_service_name("image_raw", false);
+  pub_ = image_transport::create_camera_publisher(this, topic_name);
 
   flip_horizontal_ = this->declare_parameter("flip_horizontal", false);
   flip_vertical_ = this->declare_parameter("flip_vertical", false);

--- a/image_view/src/disparity_view_node.cpp
+++ b/image_view/src/disparity_view_node.cpp
@@ -65,10 +65,14 @@ namespace image_view
 DisparityViewNode::DisparityViewNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("disparity_view_node", options)
 {
-  std::string topic =
-    rclcpp::expand_topic_or_service_name("image", this->get_name(), this->get_namespace());
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string topic = node_base->resolve_topic_or_service_name("image", false);
 
-  if (topic == "image") {
+  auto topics = this->get_topic_names_and_types();
+
+  if (topics.find(topic) == topics.end()) {
     RCLCPP_WARN(
       this->get_logger(), "Topic 'image' has not been remapped! Typical command-line usage:\n"
       "\t$ ros2 run image_view disparity_view --ros-args -r image:=<disparity image topic>");

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -70,8 +70,10 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("extract_images_node", options),
   filename_format_(""), count_(0), _time(this->now())
 {
-  auto topic = rclcpp::expand_topic_or_service_name(
-    "image", this->get_name(), this->get_namespace());
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string topic = node_base->resolve_topic_or_service_name("image", false);
 
   this->declare_parameter<std::string>("transport", std::string("raw"));
   std::string transport = this->get_parameter("transport").as_string();
@@ -83,7 +85,7 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
 
   auto topics = this->get_topic_names_and_types();
 
-  if (topics.find(topic) != topics.end()) {
+  if (topics.find(topic) == topics.end()) {
     RCLCPP_WARN(
       this->get_logger(), "extract_images: image has not been remapped! "
       "Typical command-line usage:\n\t$ ros2 run image_view extract_images "

--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -70,8 +70,10 @@ namespace image_view
 ImageSaverNode::ImageSaverNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("image_saver_node", options)
 {
-  auto topic = rclcpp::expand_topic_or_service_name(
-    "image", this->get_name(), this->get_namespace());
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string topic = node_base->resolve_topic_or_service_name("image", false);
 
   // Useful when CameraInfo is being published
   cam_sub_ = image_transport::create_camera_subscription(

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -109,9 +109,10 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
   cv::setMouseCallback("right", &StereoViewNode::mouseCb, this);
   cv::setMouseCallback("disparity", &StereoViewNode::mouseCb, this);
 
-  // Resolve topic names
-  std::string stereo_ns = rclcpp::expand_topic_or_service_name(
-    "stereo", this->get_name(), this->get_namespace());
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string stereo_ns = node_base->resolve_topic_or_service_name("stereo", false);
 
   std::string left_topic = rclcpp::expand_topic_or_service_name(
     stereo_ns + "/left" + rclcpp::expand_topic_or_service_name(

--- a/image_view/src/video_recorder_node.cpp
+++ b/image_view/src/video_recorder_node.cpp
@@ -66,8 +66,11 @@ VideoRecorderNode::VideoRecorderNode(const rclcpp::NodeOptions & options)
     rclcpp::shutdown();
   }
 
-  auto topic = rclcpp::expand_topic_or_service_name(
-    "image", this->get_name(), this->get_namespace());
+  // For compressed topics to remap appropriately, we need to pass a
+  // fully expanded and remapped topic name to image_transport
+  auto node_base = this->get_node_base_interface();
+  std::string topic = node_base->resolve_topic_or_service_name("image", false);
+
   sub_image = image_transport::create_subscription(
     this, topic, std::bind(&VideoRecorderNode::callback, this, std::placeholders::_1), "raw");
 


### PR DESCRIPTION
## Before:

Pushing into namespace is broken, only image_raw changes (camera_info and transport topics should change):
```
ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
---
ros2 topic list
/camera_info
/foo/image_raw
/image_raw/compressed
/image_raw/compressedDepth
/image_raw/theora
```

Changing the name is also broken - only image_raw changes (transport topics should change):
```
ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=image2
---
ros2 topic list
/camera_info
/image2
/image_raw/compressed
/image_raw/compressedDepth
/image_raw/theora
```

## After:

No remap still works:
```
ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png
---
ros2 topic list
/camera_info
/image_raw
/image_raw/compressed
/image_raw/compressedDepth
/image_raw/theora
```

Pushing into namespace now works:
```
ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=foo/image_raw
---
ros2 topic list
/foo/camera_info
/foo/image_raw
/foo/image_raw/compressed
/foo/image_raw/compressedDepth
/foo/image_raw/theora
```

Changing the name works correctly:
```
ros2 run image_publisher image_publisher_node --ros-args -p filename:=test.png -r image_raw:=image2
---
ros2 topic list
/camera_info
/image2
/image2/compressed
/image2/compressedDepth
/image2/theora
```