### PR TITLE
allow use as component or node

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -36,17 +36,46 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/register.cpp
 )
 
-rclcpp_components_register_nodes(${PROJECT_NAME}
-  "${PROJECT_NAME}::ConvertMetricNode"
-  "${PROJECT_NAME}::CropForemostNode"
-  "${PROJECT_NAME}::DisparityNode"
-  "${PROJECT_NAME}::PointCloudXyzNode"
-  "${PROJECT_NAME}::PointCloudXyzRadialNode"
-  "${PROJECT_NAME}::PointCloudXyziNode"
-  "${PROJECT_NAME}::PointCloudXyziRadialNode"
-  "${PROJECT_NAME}::PointCloudXyzrgbNode"
-  "${PROJECT_NAME}::PointCloudXyzrgbRadialNode"
-  "${PROJECT_NAME}::RegisterNode"
+# Register individual components and also build standalone nodes for each
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::ConvertMetricNode"
+  EXECUTABLE convert_metric_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::CropForemostNode"
+  EXECUTABLE crop_foremost_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::DisparityNode"
+  EXECUTABLE disparity_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyzNode"
+  EXECUTABLE point_cloud_xyz_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyzrgbNode"
+  EXECUTABLE point_cloud_xyzrgb_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyziNode"
+  EXECUTABLE point_cloud_xyzi_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyzRadialNode"
+  EXECUTABLE point_cloud_xyz_radial_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyziRadialNode"
+  EXECUTABLE point_cloud_xyzi_radial_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::PointCloudXyziRadialNode"
+  EXECUTABLE point_cloud_xyzrgb_radial_node
+)
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "depth_image_proc::RegisterNode"
+  EXECUTABLE register_node
 )
 
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})

--- a/image_proc/CMakeLists.txt
+++ b/image_proc/CMakeLists.txt
@@ -26,16 +26,18 @@ target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
 
-# rectify library
+# rectify component and node
 ament_auto_add_library(rectify SHARED
   src/rectify.cpp)
 target_compile_definitions(rectify
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(rectify "image_proc::RectifyNode")
-set(node_plugins "${node_plugins}image_proc::RectifyNode;$<TARGET_FILE:rectify>\n")
+rclcpp_components_register_node(rectify
+  PLUGIN "image_proc::RectifyNode"
+  EXECUTABLE rectify_node
+)
 
-# debayer library
+# debayer component and node
 ament_auto_add_library(debayer SHARED
   src/debayer.cpp
   src/edge_aware.cpp
@@ -43,38 +45,46 @@ ament_auto_add_library(debayer SHARED
 target_compile_definitions(debayer
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(debayer "image_proc::DebayerNode")
-set(node_plugins "${node_plugins}image_proc::DebayerNode;$<TARGET_FILE:debayer>\n")
+rclcpp_components_register_node(debayer
+  PLUGIN "image_proc::DebayerNode"
+  EXECUTABLE debayer_node
+)
 
-# resize library
+# resize component and node
 ament_auto_add_library(resize SHARED
   src/resize.cpp
 )
 target_compile_definitions(resize
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(resize "image_proc::ResizeNode")
-set(node_plugins "${node_plugins}image_proc::ResizeNode;$<TARGET_FILE:resize>\n")
+rclcpp_components_register_node(resize
+  PLUGIN "image_proc::ResizeNode"
+  EXECUTABLE resize_node
+)
 
-# crop_decimate library
+# crop_decimate component and node
 ament_auto_add_library(crop_decimate SHARED
   src/crop_decimate.cpp
 )
 target_compile_definitions(crop_decimate
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(crop_decimate "image_proc::CropDecimateNode")
-set(node_plugins "${node_plugins}image_proc::CropDecimateNode;$<TARGET_FILE:crop_decimate>\n")
+rclcpp_components_register_node(crop_decimate
+  PLUGIN "image_proc::CropDecimateNode"
+  EXECUTABLE crop_decimate_node
+)
 
-# crop_non_zero library
+# crop_non_zero component and node
 ament_auto_add_library(crop_non_zero SHARED
   src/crop_non_zero.cpp
 )
 target_compile_definitions(crop_non_zero
   PRIVATE "COMPOSITION_BUILDING_DLL"
 )
-rclcpp_components_register_nodes(crop_non_zero "image_proc::CropNonZeroNode")
-set(node_plugins "${node_plugins}image_proc::CropNonZeroNode;$<TARGET_FILE:crop_non_zero>\n")
+rclcpp_components_register_node(crop_non_zero
+  PLUGIN "image_proc::CropNonZeroNode"
+  EXECUTABLE crop_non_zero_node
+)
 
 # image_proc example node
 ament_auto_add_executable(image_proc_exe

--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
 
+# Register individual components and also build standalone nodes for each
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "stereo_image_proc::DisparityNode"
   EXECUTABLE disparity_node


### PR DESCRIPTION
This addresses https://github.com/ros-perception/image_pipeline/issues/823:

 * depth_image_proc was never implemented properly this way
 * image_proc might have once worked this way, but it appears upstream has changed over time and it was no longer doing the job.
 * stereo_image_proc is actually implemented correctly - I just added a comment

With this PR:

```
$ ros2 pkg executables image_proc
image_proc crop_decimate_node
image_proc crop_non_zero_node
image_proc debayer_node
image_proc image_proc
image_proc rectify_node
image_proc resize_node
```
```
$ ros2 pkg executables depth_image_proc
depth_image_proc convert_metric_node
depth_image_proc crop_foremost_node
depth_image_proc disparity_node
depth_image_proc point_cloud_xyz_node
depth_image_proc point_cloud_xyz_radial_node
depth_image_proc point_cloud_xyzi_node
depth_image_proc point_cloud_xyzi_radial_node
depth_image_proc point_cloud_xyzrgb_node
depth_image_proc point_cloud_xyzrgb_radial_node
depth_image_proc register_node
```