### PR TITLE
image_rotate: clean up

### DIFF
--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -82,10 +82,6 @@ private:
   void do_work(
     const sensor_msgs::msg::Image::ConstSharedPtr & msg,
     const std::string input_frame_from_msg);
-  void subscribe();
-  void unsubscribe();
-  void connectCb();
-  void disconnectCb();
   void onInit();
 
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;

--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -66,6 +66,7 @@ struct ImageRotateConfig
   bool use_camera_info;
   double max_angular_rate;
   double output_image_size;
+  std::string transport;
 };
 
 class ImageRotateNode : public rclcpp::Node

--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -66,7 +66,6 @@ struct ImageRotateConfig
   bool use_camera_info;
   double max_angular_rate;
   double output_image_size;
-  std::string transport;
 };
 
 class ImageRotateNode : public rclcpp::Node

--- a/image_rotate/src/image_rotate.cpp
+++ b/image_rotate/src/image_rotate.cpp
@@ -38,13 +38,6 @@ int main(int argc, char ** argv)
   // Force flush of the stdout buffer.
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
-  if (argc <= 1) {
-    RCUTILS_LOG_WARN(
-      "Topic 'image' has not been remapped! Typical command-line usage:\n"
-      "\t$ ros2 run image_rotate image_rotate image:=<image topic>");
-    return 1;
-  }
-
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions options;
   auto node = std::make_shared<image_rotate::ImageRotateNode>(options);

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -72,31 +72,9 @@ namespace image_rotate
 ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ImageRotateNode", options)
 {
-  config_.target_frame_id = this->declare_parameter("target_frame_id", std::string(""));
-  config_.target_x = this->declare_parameter("target_x", 0.0);
-  config_.target_y = this->declare_parameter("target_y", 0.0);
-  config_.target_z = this->declare_parameter("target_z", 1.0);
-
-  config_.source_frame_id = this->declare_parameter("source_frame_id", std::string(""));
-  config_.source_x = this->declare_parameter("source_x", 0.0);
-  config_.source_y = this->declare_parameter("source_y", -1.0);
-  config_.source_z = this->declare_parameter("source_z", 0.0);
-
-  config_.output_frame_id = this->declare_parameter("output_frame_id", std::string(""));
-  config_.input_frame_id = this->declare_parameter("input_frame_id", std::string(""));
-  config_.use_camera_info = this->declare_parameter("use_camera_info", true);
-  config_.max_angular_rate = this->declare_parameter(
-    "max_angular_rate",
-    10.0);
-  config_.output_image_size = this->declare_parameter(
-    "output_image_size",
-    2.0);
-
   auto reconfigureCallback =
     [this](std::vector<rclcpp::Parameter> parameters) -> rcl_interfaces::msg::SetParametersResult
     {
-      RCLCPP_INFO(get_logger(), "reconfigureCallback");
-
       auto result = rcl_interfaces::msg::SetParametersResult();
       result.successful = true;
       for (auto parameter : parameters) {
@@ -128,6 +106,7 @@ ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions & options)
       source_vector_.vector.x = config_.source_x;
       source_vector_.vector.y = config_.source_y;
       source_vector_.vector.z = config_.source_z;
+
       if (subscriber_count_) {  // @todo: Could do this without an interruption at some point.
         unsubscribe();
         subscribe();
@@ -135,6 +114,24 @@ ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions & options)
       return result;
     };
   on_set_parameters_callback_handle_ = this->add_on_set_parameters_callback(reconfigureCallback);
+
+  // Set parameters AFTER add_on_set_parameters_callback
+  config_.target_frame_id = this->declare_parameter("target_frame_id", std::string(""));
+  config_.target_x = this->declare_parameter("target_x", 0.0);
+  config_.target_y = this->declare_parameter("target_y", 0.0);
+  config_.target_z = this->declare_parameter("target_z", 1.0);
+
+  config_.source_frame_id = this->declare_parameter("source_frame_id", std::string(""));
+  config_.source_x = this->declare_parameter("source_x", 0.0);
+  config_.source_y = this->declare_parameter("source_y", -1.0);
+  config_.source_z = this->declare_parameter("source_z", 0.0);
+
+  config_.output_frame_id = this->declare_parameter("output_frame_id", std::string(""));
+  config_.input_frame_id = this->declare_parameter("input_frame_id", std::string(""));
+  config_.use_camera_info = this->declare_parameter("use_camera_info", true);
+  config_.max_angular_rate = this->declare_parameter("max_angular_rate", 10.0);
+  config_.output_image_size = this->declare_parameter("output_image_size", 2.0);
+
   onInit();
 }
 

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -267,7 +267,8 @@ void ImageRotateNode::do_work(
     out_img->header.frame_id = transform.child_frame_id;
     img_pub_.publish(out_img);
   } catch (const cv::Exception & e) {
-    RCLCPP_ERROR(get_logger(),
+    RCLCPP_ERROR(
+      get_logger(),
       "Image processing error: %s %s %s %i",
       e.err.c_str(), e.func.c_str(), e.file.c_str(), e.line);
   }
@@ -290,7 +291,6 @@ void ImageRotateNode::onInit()
   pub_options.event_callbacks.matched_callback =
     [this](rclcpp::MatchedInfo &)
     {
-      //std::lock_guard<std::mutex> lock(connect_mutex_);
       if (img_pub_.getNumSubscribers() == 0) {
         RCLCPP_DEBUG(get_logger(), "Unsubscribing from image topic.");
         img_sub_.shutdown();
@@ -304,7 +304,8 @@ void ImageRotateNode::onInit()
         // Check that remapping appears to be correct
         auto topics = this->get_topic_names_and_types();
         if (topics.find(topic_name) == topics.end()) {
-          RCLCPP_WARN(get_logger(),
+          RCLCPP_WARN(
+            get_logger(),
             "Topic %s is not connected! Typical command-line usage:\n"
             "\t$ ros2 run image_rotate image_rotate --ros-args -r image:=<image topic>",
             topic_name.c_str());
@@ -335,7 +336,8 @@ void ImageRotateNode::onInit()
         }
       }
     };
-  img_pub_ = image_transport::create_publisher(this, "rotated/image", rmw_qos_profile_default, pub_options);
+  img_pub_ = image_transport::create_publisher(
+    this, "rotated/image", rmw_qos_profile_default, pub_options);
 }
 }  // namespace image_rotate
 

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -128,6 +128,9 @@ ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions & options)
   config_.max_angular_rate = this->declare_parameter("max_angular_rate", 10.0);
   config_.output_image_size = this->declare_parameter("output_image_size", 2.0);
 
+  // Allow overriding the SUBSCRIBER transport
+  config_.transport = this->declare_parameter("image_transport", "raw");
+
   onInit();
 }
 
@@ -319,7 +322,7 @@ void ImageRotateNode::onInit()
             std::bind(
               &ImageRotateNode::imageCallbackWithInfo, this,
               std::placeholders::_1, std::placeholders::_2),
-            "raw",
+            config_.transport,
             custom_qos);
         } else {
           auto custom_qos = rmw_qos_profile_system_default;
@@ -328,7 +331,7 @@ void ImageRotateNode::onInit()
             this,
             topic_name,
             std::bind(&ImageRotateNode::imageCallback, this, std::placeholders::_1),
-            "raw",
+            config_.transport,
             custom_qos);
         }
       }


### PR DESCRIPTION
This is the first component/node with a cleanup pass to be fully implemented:

 * Fix #740 by initializing vectors. Do this by declaring parameters AFTER we define the callback
 * Implement lazy subscribers (I missed this in the earlier PRs)
 * Add image_transport parameter so we can specify that desired transport of our subscriptions
 * Update how we test for connectivity (and update the debug message - has nothing to do with whether we are remapped, it's really about whether we are connected)