### PR TITLE
[backport Humble] use cv::DestroyAllWindows (#863)

### DIFF
--- a/image_view/src/disparity_view_node.cpp
+++ b/image_view/src/disparity_view_node.cpp
@@ -88,7 +88,7 @@ DisparityViewNode::DisparityViewNode(const rclcpp::NodeOptions & options)
 
 DisparityViewNode::~DisparityViewNode()
 {
-  cv::destroyWindow(window_name_);
+  cv::destroyAllWindows();
 }
 
 void DisparityViewNode::imageCb(const stereo_msgs::msg::DisparityImage::SharedPtr msg)

--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -259,7 +259,7 @@ void ImageViewNode::windowThread()
     }
   }
 
-  cv::destroyWindow(window_name_);
+  cv::destroyAllWindows();
 
   if (rclcpp::ok()) {
     rclcpp::shutdown();


### PR DESCRIPTION
This ports #816 to ROS 2 and prevents weird exit conditions if you already closed the window

backport https://github.com/ros-perception/image_pipeline/pull/863