### PR TITLE
Support MONO16 image encodings: point_cloud_xyz

### DIFF
--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -98,7 +98,7 @@ void PointCloudXyzNode::depthCb(
   model_.fromCameraInfo(info_msg);
 
   // Convert Depth Image to Pointcloud
-  if (depth_msg->encoding == enc::TYPE_16UC1) {
+  if (depth_msg->encoding == enc::TYPE_16UC1 || depth_msg->encoding == enc::MONO16) {
     convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
     convertDepth<float>(depth_msg, cloud_msg, model_);


### PR DESCRIPTION
Related with this change in ROS 1 https://github.com/ros-perception/image_pipeline/pull/630