### PR TITLE
enable autosize parameter in disparity view

### DIFF
--- a/image_view/include/image_view/disparity_view_node.hpp
+++ b/image_view/include/image_view/disparity_view_node.hpp
@@ -41,6 +41,7 @@ private:
   static unsigned char colormap[];
 
   std::string window_name_;
+  bool autosize_;
   rclcpp::Subscription<stereo_msgs::msg::DisparityImage>::SharedPtr sub_;
   cv::Mat_<cv::Vec3b> disparity_color_;
   bool initialized;

--- a/image_view/src/disparity_view_node.cpp
+++ b/image_view/src/disparity_view_node.cpp
@@ -82,9 +82,7 @@ DisparityViewNode::DisparityViewNode(const rclcpp::NodeOptions & options)
 
   // Default window name is the resolved topic name
   window_name_ = this->declare_parameter("window_name", topic);
-  // bool autosize = this->declare_parameter("autosize", false);
-
-  // cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
+  autosize_ = this->declare_parameter("autosize", false);
 
   sub_ = this->create_subscription<stereo_msgs::msg::DisparityImage>(
     topic, rclcpp::QoS(10), std::bind(&DisparityViewNode::imageCb, this, std::placeholders::_1));
@@ -114,7 +112,7 @@ void DisparityViewNode::imageCb(const stereo_msgs::msg::DisparityImage::SharedPt
   }
 
   if (!initialized) {
-    cv::namedWindow(window_name_, false ? cv::WND_PROP_AUTOSIZE : 0);
+    cv::namedWindow(window_name_, autosize_ ? cv::WND_PROP_AUTOSIZE : 0);
     initialized = true;
   }
 


### PR DESCRIPTION
appears to be bug left over from ROS 2 port