### PR TITLE
[backport iron] stereo_image_proc: cleanup cmake (#904)

### DIFF
--- a/stereo_image_proc/CMakeLists.txt
+++ b/stereo_image_proc/CMakeLists.txt
@@ -45,22 +45,13 @@ if(BUILD_TESTING)
     set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
   endif()
 
-  # Test DisparityNode in launch test
-  add_launch_test("test/test_disparity_node.py"
+  ament_add_pytest_test("test_disparity_node" test/test_disparity_node.py
     PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
   )
-  # TODO(jacobperron): As of Eloquent, they're just plain pytests
-  # ament_add_pytest_test("test_disparity_node" test/test_disparity_node.py
-  #   PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
-  # )
 
-  # Test PointCloudNode in launch test
-  add_launch_test("test/test_point_cloud_node.py"
+  ament_add_pytest_test("test_point_cloud_node" test/test_point_cloud_node.py
     PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
   )
-  # ament_add_pytest_test("test_point_cloud_node" test/test_point_cloud_node.py
-  #   PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
-  # )
 
   set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 endif()


### PR DESCRIPTION
This was supposed to be switched over when e-turtle rolled out. J-turtle ain't that late...

backport https://github.com/ros-perception/image_pipeline/pull/904