### PR TITLE
remove the last bit of boost

### DIFF
--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -24,7 +24,6 @@
   <depend>camera_calibration_parsers</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
-  <depend>libboost-dev</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
Last bit of #407 - every other occurrence of "boost" when grepping the repo is in the changelog