### PR TITLE
Update extract_images_sync to add sec_per_frame parameter

### DIFF
--- a/image_view/scripts/extract_images_sync
+++ b/image_view/scripts/extract_images_sync
@@ -51,10 +51,19 @@ class ExtractImagesSync(Node):
         super().__init__('extract_images_sync')
         self.get_logger().info('Extract_Images_Sync Node has been started')
         self.seq = 0
+        self.time = self.get_clock().now()
+
         self.fname_fmt = self.declare_parameter(
-            'filename_format', 'frame%04i_%i.jpg').value   
+            'filename_format', 'frame%04i_%i.jpg').value
+
+        # Do not scale dynamically by default.
         self.do_dynamic_scaling = self.declare_parameter(
             'do_dynamic_scaling', False).value
+
+        # Limit the throughput to 10fps by default.
+        self.sec_per_frame = self.declare_parameter(
+            'sec_per_frame', 0.1).value
+
         img_topics = self.declare_parameter('inputs', None).value
 
         if img_topics is None:
@@ -80,6 +89,17 @@ Typical command-line usage:
         sync.registerCallback(self.save)
 
     def save(self, *imgmsgs):
+        delay = self.get_clock().now() - self.time
+
+        # Decimation is enabled if it is set to greater than
+        # zero. If it is enabled, exit if delay is less than
+        # the decimation rate specified.
+        if (self.sec_per_frame > 0) and (delay < self.sec_per_frame):
+            return
+        
+        # Update the current time
+        self.time = self.get_clock().now()
+
         seq = self.seq
         bridge = cv_bridge.CvBridge()
         for i, imgmsg in enumerate(imgmsgs):

--- a/image_view/scripts/extract_images_sync
+++ b/image_view/scripts/extract_images_sync
@@ -42,6 +42,7 @@ import cv_bridge
 import rclpy
 
 from rclpy.node import Node
+from rclpy.duration import Duration
 from sensor_msgs.msg import Image
 from message_filters import ApproximateTimeSynchronizer, TimeSynchronizer, Subscriber
 
@@ -62,7 +63,7 @@ class ExtractImagesSync(Node):
 
         # Limit the throughput to 10fps by default.
         self.sec_per_frame = self.declare_parameter(
-            'sec_per_frame', 0).value
+            'sec_per_frame', 0.0).value
 
         img_topics = self.declare_parameter('inputs', None).value
 
@@ -94,7 +95,7 @@ Typical command-line usage:
         # Decimation is enabled if it is set to greater than
         # zero. If it is enabled, exit if delay is less than
         # the decimation rate specified.
-        if (self.sec_per_frame > 0) and (delay.to_sec() < self.sec_per_frame):
+        if (self.sec_per_frame > 0) and (delay < Duration(seconds=self.sec_per_frame)):
             return
         
         # Update the current time

--- a/image_view/scripts/extract_images_sync
+++ b/image_view/scripts/extract_images_sync
@@ -51,7 +51,7 @@ class ExtractImagesSync(Node):
         super().__init__('extract_images_sync')
         self.get_logger().info('Extract_Images_Sync Node has been started')
         self.seq = 0
-        self.time = self.get_clock().now()
+        self.last_frame_time = self.get_clock().now()
 
         self.fname_fmt = self.declare_parameter(
             'filename_format', 'frame%04i_%i.jpg').value
@@ -62,7 +62,7 @@ class ExtractImagesSync(Node):
 
         # Limit the throughput to 10fps by default.
         self.sec_per_frame = self.declare_parameter(
-            'sec_per_frame', 0.1).value
+            'sec_per_frame', 0).value
 
         img_topics = self.declare_parameter('inputs', None).value
 
@@ -89,7 +89,7 @@ Typical command-line usage:
         sync.registerCallback(self.save)
 
     def save(self, *imgmsgs):
-        delay = self.get_clock().now() - self.time
+        delay = self.get_clock().now() - self.last_frame_time
 
         # Decimation is enabled if it is set to greater than
         # zero. If it is enabled, exit if delay is less than
@@ -98,7 +98,7 @@ Typical command-line usage:
             return
         
         # Update the current time
-        self.time = self.get_clock().now()
+        self.last_frame_time = self.get_clock().now()
 
         seq = self.seq
         bridge = cv_bridge.CvBridge()

--- a/image_view/scripts/extract_images_sync
+++ b/image_view/scripts/extract_images_sync
@@ -94,7 +94,7 @@ Typical command-line usage:
         # Decimation is enabled if it is set to greater than
         # zero. If it is enabled, exit if delay is less than
         # the decimation rate specified.
-        if (self.sec_per_frame > 0) and (delay < self.sec_per_frame):
+        if (self.sec_per_frame > 0) and (delay.to_sec() < self.sec_per_frame):
             return
         
         # Update the current time


### PR DESCRIPTION
Added sec_per_frame parameter to allow decimation of frames being synchronized and captured.
fixes #726 