### PR TITLE
update readme with links to docs, badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 image_pipeline
 ==============
 
-[![](https://github.com/ros-perception/image_pipeline/workflows/Basic%20Build%20Workflow/badge.svg?branch=ros2)](https://github.com/ros-perception/image_pipeline/actions)
+[![Build Status](https://build.ros2.org/buildStatus/icon?job=Rdev__image_pipeline__ubuntu_jammy_amd64)](https://build.ros2.org/job/Rdev__image_pipeline__ubuntu_jammy_amd64/)
 
 This package fills the gap between getting raw images from a camera driver and higher-level vision processing.
 
-For more information on this metapackage and underlying packages, please see [the ROS wiki entry](http://wiki.ros.org/image_pipeline).
+Documentation is hosted in the ROS 2 API docs.
+The [image_pipeline](http://docs.ros.org/en/rolling/p/image_pipeline/)
+documentation includes an overview,
+[details on camera_info](http://docs.ros.org/en/rolling/p/image_pipeline/camera_info.html),
+and links to the documentation for each individual package.
 
-For examples, see the [image_pipeline tutorials entry](http://wiki.ros.org/image_pipeline/Tutorials) on the ROS Wiki.
+Not every aspect has been ported to the new ROS 2 API documentation yet, so
+there is still additional (partially outdated) information
+in [the ROS wiki entry](http://wiki.ros.org/image_pipeline).


### PR DESCRIPTION
image_proc, image_pipeline, and depth_image_proc are now live on docs.ros.org, so we should point at that