### PR TITLE
924 introduce default depth param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *pyc
-.vscode/settings.json
+.vscode/
 */doc/generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 *pyc
 .vscode/
 */doc/generated
-/build/
-/log/
-/install/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *pyc
 .vscode/
 */doc/generated
+/build/
+/log/
+/install/

--- a/depth_image_proc/doc/components.rst
+++ b/depth_image_proc/doc/components.rst
@@ -116,6 +116,8 @@ Parameters
    for the depth topic subscriber.
  * **queue_size** (int, default: 5): Size of message queue for synchronizing
    subscribed topics.
+ * **invalid_depth** (double, default: 0.0): Value used for replacing invalid depth
+   values (if 0.0 the parameter has no effect).
 
 depth_image_proc::PointCloudXyzRadialNode
 -----------------------------------------
@@ -165,6 +167,8 @@ Parameters
    the intensity image subscriber.
  * **queue_size** (int, default: 5): Size of message queue for synchronizing
    subscribed topics.
+ * **invalid_depth** (double, default: 0.0): Value used for replacing invalid depth
+   values (if 0.0 the parameter has no effect).
 
 depth_image_proc::PointCloudXyziRadialNode
 ------------------------------------------
@@ -235,6 +239,8 @@ Parameters
  * **exact_sync** (bool, default: False): Whether to use exact synchronizer.
  * **queue_size** (int, default: 5): Size of message queue for synchronizing
    subscribed topics.
+ * **invalid_depth** (double, default: 0.0): Value used for replacing invalid depth
+   values (if 0.0 the parameter has no effect).
 
 depth_image_proc::PointCloudXyzrgbRadialNode
 --------------------------------------------

--- a/depth_image_proc/include/depth_image_proc/conversions.hpp
+++ b/depth_image_proc/include/depth_image_proc/conversions.hpp
@@ -75,7 +75,6 @@ void convertDepth(
   sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
 
-  // TODO(philipppolterauer): i think this is undefined behaviour we should favor memcpy? https://stackoverflow.com/questions/55150001/vector-with-reinterpret-cast
   const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
   uint32_t row_step = depth_msg->step / sizeof(T);
   for (uint32_t v = 0; v < cloud_msg->height; ++v, depth_row += row_step) {

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
@@ -67,6 +67,9 @@ private:
   image_transport::CameraSubscriber sub_depth_;
   int queue_size_;
 
+  // Parameters
+  double invalid_depth_;
+
   // Publications
   std::mutex connect_mutex_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
@@ -71,6 +71,9 @@ private:
   using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
   std::shared_ptr<Synchronizer> sync_;
 
+  // parameters
+  float invalid_depth_;
+
   // Publications
   std::mutex connect_mutex_;
   rclcpp::Publisher<PointCloud>::SharedPtr pub_point_cloud_;

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
@@ -75,6 +75,9 @@ private:
   std::shared_ptr<Synchronizer> sync_;
   std::shared_ptr<ExactSynchronizer> exact_sync_;
 
+  // parameters
+  float invalid_depth_;
+
   // Publications
   std::mutex connect_mutex_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;

--- a/depth_image_proc/src/conversions.cpp
+++ b/depth_image_proc/src/conversions.cpp
@@ -79,7 +79,7 @@ cv::Mat initMatrix(
 
 void convertRgb(
   const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  const sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
   int red_offset, int green_offset, int blue_offset, int color_step)
 {
   sensor_msgs::PointCloud2Iterator<uint8_t> iter_r(*cloud_msg, "r");
@@ -101,7 +101,7 @@ void convertRgb(
 // force template instantiation
 template void convertDepth<uint16_t>(
   const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  const sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
   const image_geometry::PinholeCameraModel & model,
   double range_max);
 

--- a/depth_image_proc/src/conversions.cpp
+++ b/depth_image_proc/src/conversions.cpp
@@ -103,6 +103,6 @@ template void convertDepth<uint16_t>(
   const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
   const sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
   const image_geometry::PinholeCameraModel & model,
-  double range_max);
+  double invalid_depth);
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -59,8 +59,8 @@ PointCloudXyzNode::PointCloudXyzNode(const rclcpp::NodeOptions & options)
   queue_size_ = this->declare_parameter<int>("queue_size", 5);
 
   // values used for invalid points for pcd conversion
-  invalid_depth_ = this->declare_parameter<double>("invalid_depth_", 0.0);
-  
+  invalid_depth_ = this->declare_parameter<double>("invalid_depth", 0.0);
+
   // Create publisher with connect callback
   rclcpp::PublisherOptions pub_options;
   pub_options.event_callbacks.matched_callback =
@@ -97,7 +97,7 @@ void PointCloudXyzNode::depthCb(
   const Image::ConstSharedPtr & depth_msg,
   const CameraInfo::ConstSharedPtr & info_msg)
 {
-  auto cloud_msg = std::make_shared<PointCloud2>();
+  const PointCloud2::SharedPtr cloud_msg = std::make_shared<PointCloud2>();
   cloud_msg->header = depth_msg->header;
   cloud_msg->height = depth_msg->height;
   cloud_msg->width = depth_msg->width;

--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -58,6 +58,9 @@ PointCloudXyzNode::PointCloudXyzNode(const rclcpp::NodeOptions & options)
   // Read parameters
   queue_size_ = this->declare_parameter<int>("queue_size", 5);
 
+  // values used for invalid points for pcd conversion
+  invalid_depth_ = this->declare_parameter<double>("invalid_depth_", 0.0);
+  
   // Create publisher with connect callback
   rclcpp::PublisherOptions pub_options;
   pub_options.event_callbacks.matched_callback =
@@ -109,9 +112,9 @@ void PointCloudXyzNode::depthCb(
 
   // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == enc::TYPE_16UC1 || depth_msg->encoding == enc::MONO16) {
-    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
+    convertDepth<uint16_t>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
-    convertDepth<float>(depth_msg, cloud_msg, model_);
+    convertDepth<float>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else {
     RCLCPP_ERROR(
       get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -58,6 +58,9 @@ PointCloudXyziNode::PointCloudXyziNode(const rclcpp::NodeOptions & options)
   this->declare_parameter<std::string>("image_transport", "raw");
   this->declare_parameter<std::string>("depth_image_transport", "raw");
 
+  // value used for invalid points for pcd conversion
+  invalid_depth_ = this->declare_parameter<double>("invalid_depth", 0.0);
+
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
 
@@ -202,9 +205,9 @@ void PointCloudXyziNode::imageCb(
 
   // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == enc::TYPE_16UC1) {
-    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
+    convertDepth<uint16_t>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
-    convertDepth<float>(depth_msg, cloud_msg, model_);
+    convertDepth<float>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else {
     RCLCPP_ERROR(
       get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -55,6 +55,9 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
   this->declare_parameter<std::string>("image_transport", "raw");
   this->declare_parameter<std::string>("depth_image_transport", "raw");
 
+  // value used for invalid points for pcd conversion
+  invalid_depth_ = this->declare_parameter<double>("invalid_depth", 0.0);
+
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
   bool use_exact_sync = this->declare_parameter<bool>("exact_sync", false);
@@ -256,9 +259,9 @@ void PointCloudXyzrgbNode::imageCb(
 
   // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
-    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
+    convertDepth<uint16_t>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1) {
-    convertDepth<float>(depth_msg, cloud_msg, model_);
+    convertDepth<float>(depth_msg, cloud_msg, model_, invalid_depth_);
   } else {
     RCLCPP_ERROR(
       get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());


### PR DESCRIPTION
this pull request attempts to fix #924 

changes:
- [x] changed the argument name `range_max` which was missleading to `invalid_depth` which captures the true meaning of the paramter
- [x] Introduction of a parameter called `invalid_depth`, which is the value that will be assigned to points that are not valid according to `DepthTraits<T>::valid`
- [x] small fixes regarding use of non const shared ptr references
- [x] changed for loop from int to uint32_t avoiding many type casts

Open:

- [ ] UB when reinterpret casting the pointcloud data? 
- [ ] introduction of a true "max_depth" or "max_range" paramter 

Comment:
i think the term range and depth is not always used consistently, my understanding is
*range* meaning point to point distance, and *depth* point to camera plane distance