### PR TITLE
Update depth_image_proc::RegisterNode documentation

### DIFF
--- a/depth_image_proc/doc/components.rst
+++ b/depth_image_proc/doc/components.rst
@@ -297,6 +297,8 @@ Parameters
 ^^^^^^^^^^
  * **depth_image_transport** (string, default: raw): Image transport to use
    for depth subscriber.
+ * **use_rgb_timestamp** (bool, default: false) : use timestamp of rgb image instead of depth image for the registered image.
+ * **fill_upsampling_holes** (bool, default: false) : when RGB is higher res, interpolate by rasterizing depth triangles onto the registered image.
  * **queue_size** (int, default: 5): Size of message queue for synchronizing
    subscribed topics.
 


### PR DESCRIPTION
Adding missing parameters from register node of depth_image_proc package.
Related to Issue #956 