### PR TITLE
Fix parameter names in components.rst

### DIFF
--- a/image_proc/doc/components.rst
+++ b/image_proc/doc/components.rst
@@ -42,8 +42,8 @@ Parameters
  * **queue_size** (int, default: 5): Size of message queue for synchronizing
    image and camera_info topics. You may need to raise this if images take
    significantly longer to travel over the network than camera info.
- * **x_offset** (int, default: 0): X offset of the region of interest. Range: 0 to 2447
- * **y_offset** (int, default: 0): Y offset of the region of interest. Range: 0 to 2049
+ * **offset_x** (int, default: 0): X offset of the region of interest. Range: 0 to 2447
+ * **offset_y** (int, default: 0): Y offset of the region of interest. Range: 0 to 2049
  * **width** (int, default: 0): Width of the region of interest. Range: 0 to 2448
  * **height** (int, default: 0): Height of the region of interest. Range: 0 to 2050
 


### PR DESCRIPTION
In the docs for  `image_proc::CropDecimateNode` , change the parameter names `x_offset` and `y_offset` to `offset_x` and `offset_y`, matching the actual names of parameters defined  in [crop_decimate.cpp](https://github.com/ros-perception/image_pipeline/blob/b8839433dda96c7671e4f9b00fad37a9824fc0e7/image_proc/src/crop_decimate.cpp#L130-L131).

