### PR TITLE
Added stereo calibration using charuco board

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -482,7 +482,7 @@ class Calibrator():
         if self.pattern == Patterns.ChArUco:
             opts = [board.charuco_board.chessboardCorners for board in boards]
             return opts
-        for b in enumerate(boards):
+        for b in boards:
             num_pts = b.n_cols * b.n_rows
             opts_loc = numpy.zeros((num_pts, 1, 3), numpy.float32)
             for j in range(num_pts):

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -482,6 +482,7 @@ class Calibrator():
         if self.pattern == Patterns.ChArUco:
             opts = [board.charuco_board.chessboardCorners for board in boards]
             return opts
+        opts = []
         for b in boards:
             num_pts = b.n_cols * b.n_rows
             opts_loc = numpy.zeros((num_pts, 1, 3), numpy.float32)

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -479,8 +479,10 @@ class Calibrator():
         return list(zip(self._param_names, min_params, max_params, progress))
 
     def mk_object_points(self, boards, use_board_size = False):
-        opts = []
-        for i, b in enumerate(boards):
+        if self.pattern == Patterns.ChArUco:
+            opts = [board.charuco_board.chessboardCorners for board in boards]
+            return opts
+        for b in enumerate(boards):
             num_pts = b.n_cols * b.n_rows
             opts_loc = numpy.zeros((num_pts, 1, 3), numpy.float32)
             for j in range(num_pts):


### PR DESCRIPTION
From #972 
Doing this first for rolling.

This was a TODO in the repository, opening this PR to add this feature.
- The main issue why this wasn't possible imo is the way `mk_obj_points` works. I'm using the inbuilt opencv function to get the points there.
- The other is a condition when aruco markers are detected they are added as good points, This is fine in case of mono but in stereo these have to be the same number as the object points to find matches although this should be possible with aruco.