### PR TITLE
fix: cv2.aruco.interpolateCornersCharuco is deprecated

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -311,7 +311,7 @@ class OpenCVCalibrationNode(CalibrationNode):
         self.c.set_cammodel( CAMERA_MODEL.PINHOLE if model_select_val < 0.5 else CAMERA_MODEL.FISHEYE)
 
     def on_scale(self, scalevalue):
-        if self.c.calibrated:
+        if self.c and self.c.calibrated:
             self.c.set_alpha(scalevalue / 100.0)
 
     def button(self, dst, label, enable):


### PR DESCRIPTION
There has been API Changes in the newer releases of opencv2 (from 4.8.0). The PR addresses this by supporting both the old and new APIs. 

updated Syntax
```
charucodetector = cv2.aruco.CharucoDetector(board)
charuco_corners, charuco_ids, marker_corners, marker_ids = charucodetector.detectBoard(image)
```
before 4.8.0
```
marker_corners, marker_ids, rejectedImgPoints = cv2.aruco.detectMarkers( image, dictionary)
retval, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco( marker_corners, marker_ids, image, board)
```

See the changed examples in the main opencv2 repo:

https://github.com/opencv/opencv/blob/f9a59f2592993d3dcc080e495f4f5e02dd8ec7ef/samples/python/calibrate.py#L110