### PR TITLE
[rolling] image_publisher: Fix image, constantly flipping when static image is published

### DIFF
--- a/image_publisher/include/image_publisher/image_publisher.hpp
+++ b/image_publisher/include/image_publisher/image_publisher.hpp
@@ -67,6 +67,7 @@ private:
   std::string filename_;
   bool flip_horizontal_;
   bool flip_vertical_;
+  bool image_flipped_;
   bool retry_;  // If enabled will retry loading image from the filename_
   int timeout_;  // Time after which retrying starts
 

--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -143,10 +143,12 @@ void ImagePublisher::doWork()
     if (cap_.isOpened()) {
       if (!cap_.read(image_)) {
         cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
+        image_flipped_ = false;
       }
     }
-    if (flip_image_) {
+    if (flip_image_ && !image_flipped_) {
       cv::flip(image_, image_, flip_value_);
+      image_flipped_ = true;
     }
 
     sensor_msgs::msg::Image::SharedPtr out_img =
@@ -213,6 +215,7 @@ void ImagePublisher::onInit()
   } else {
     flip_image_ = false;
   }
+  image_flipped_ = false;  // Image newly read, needs to be flipped
 
   camera_info_.width = image_.cols;
   camera_info_.height = image_.rows;

--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -143,8 +143,8 @@ void ImagePublisher::doWork()
     if (cap_.isOpened()) {
       if (!cap_.read(image_)) {
         cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
-        image_flipped_ = false;
       }
+      image_flipped_ = false;
     }
     if (flip_image_ && !image_flipped_) {
       cv::flip(image_, image_, flip_value_);


### PR DESCRIPTION
Continuation of https://github.com/ros-perception/image_pipeline/pull/984.

When publishing video stream from a camera, the image was flipped correctly. Yet for a static image, which was loaded once, the flip function was applied every time `ImagePublisher::doWork()` was called, resulting in the published image being flipped back and forth all the time.

This PR should be straightforward to port it to `Humble`, `Iron` and `Jazzy`.