### PR TITLE
fix signature issue from #943

### DIFF
--- a/depth_image_proc/include/depth_image_proc/conversions.hpp
+++ b/depth_image_proc/include/depth_image_proc/conversions.hpp
@@ -152,7 +152,7 @@ void convertIntensity(
 // Handles RGB8, BGR8, and MONO8
 void convertRgb(
   const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr cloud_msg,
+  const sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
   int red_offset, int green_offset, int blue_offset, int color_step);
 
 cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int height, bool radial);


### PR DESCRIPTION
Without this, we get

```
symbol lookup error: /home/ubr/jazzy/install/depth_image_proc/lib/libdepth_image_proc.so: undefined symbol: _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii

c++filt _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii
depth_image_proc::convertRgb(std::shared_ptr<sensor_msgs::msg::Image_<std::allocator<void> > const> const&, std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >, int, int, int, int)
```

The issue is the loss of the & in the header, and the addition of the const in the cpp file - fix applied only to the header file.

In the future, we should create a test that catches this sort of runtime error