### PR TITLE
Use TF2 package for quaternion conversion

### DIFF
--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -30,6 +30,8 @@
   <depend>rclcpp_components</depend>
   <depend>rcutils</depend>
   <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tracetools_image_pipeline</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/image_proc/src/track_marker.cpp
+++ b/image_proc/src/track_marker.cpp
@@ -40,9 +40,10 @@
 #include <image_proc/track_marker.hpp>
 #include <image_proc/utils.hpp>
 #include <image_transport/image_transport.hpp>
-#include <opencv2/core/quaternion.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/LinearMath/Quaternion.h>
 
 namespace image_proc
 {
@@ -135,11 +136,9 @@ void TrackMarkerNode::imageCb(
       pose.pose.position.y = tvecs[0][1];
       pose.pose.position.z = tvecs[0][2];
       // Convert angle-axis to quaternion
-      cv::Quatd q = cv::Quatd::createFromRvec(rvecs[0]);
-      pose.pose.orientation.x = q.x;
-      pose.pose.orientation.y = q.y;
-      pose.pose.orientation.z = q.z;
-      pose.pose.orientation.w = q.w;
+      const tf2::Vector3 rvec(rvecs[0][0], rvecs[0][1], rvecs[0][2]);
+      const tf2::Quaternion q(rvec.normalized(), rvec.length());
+      tf2::convert(q, pose.pose.orientation);
       pub_->publish(pose);
     }
   }

--- a/image_proc/src/track_marker.cpp
+++ b/image_proc/src/track_marker.cpp
@@ -30,13 +30,14 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <tf2/LinearMath/Quaternion.h>
+
 #include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <tf2/LinearMath/Quaternion.h>
 #include <cv_bridge/cv_bridge.hpp>
 #include <image_proc/track_marker.hpp>
 #include <image_proc/utils.hpp>

--- a/image_proc/src/track_marker.cpp
+++ b/image_proc/src/track_marker.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <vector>
 
+#include <tf2/LinearMath/Quaternion.h>
 #include <cv_bridge/cv_bridge.hpp>
 #include <image_proc/track_marker.hpp>
 #include <image_proc/utils.hpp>
@@ -43,7 +44,6 @@
 #include <rclcpp/qos.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/LinearMath/Quaternion.h>
 
 namespace image_proc
 {


### PR DESCRIPTION
The OpenCV quaternion class was not added until OpenCV 4.5.1, so it's less widely available than the TF2 conversion. This change allows a source build of the ROS 2 "perception" variant on Ubuntu 20.04 without a custom source build of OpenCV.

Addresses issue https://github.com/ros-perception/image_pipeline/issues/1030