### PR TITLE
Fix #1032

### DIFF
--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -214,14 +214,14 @@ class CalibrationNode(Node):
         for i in range(10):
             print("!" * 80)
         print()
-        print("Attempt to set camera info failed: " + response.result()
-              if response.result() is not None else "Not available")
+        print("Attempt to set camera info failed: " + response.status_message
+              if response.status_message is not None else "Not available")
         print()
         for i in range(10):
             print("!" * 80)
         print()
         self.get_logger().error('Unable to set camera info for calibration. Failure message: %s' %
-                                response.result() if response.result() is not None else "Not available")
+                                response.status_message if response.status_message is not None else "Not available")
         return False
 
     def do_upload(self):


### PR DESCRIPTION
Use `status_message` from `SetCameraInfo` response instead of some non-existing `result()`.
Fixes #1032