### PR TITLE
Support QoS override parameters in depth_image_proc/register

### DIFF
--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -133,14 +133,18 @@ RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
         sub_depth_info_.unsubscribe();
         sub_rgb_info_.unsubscribe();
       } else if (!sub_depth_image_.getSubscriber()) {
+        // Allow overriding QoS settings (history, depth, reliability)
+        rclcpp::SubscriptionOptions sub_options;
+        sub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+
         // For compressed topics to remap appropriately, we need to pass a
         // fully expanded and remapped topic name to image_transport
         auto node_base = this->get_node_base_interface();
         std::string topic = node_base->resolve_topic_or_service_name("depth/image_rect", false);
         image_transport::TransportHints hints(this, "raw", "depth_image_transport");
-        sub_depth_image_.subscribe(this, topic, hints.getTransport());
-        sub_depth_info_.subscribe(this, "depth/camera_info", rclcpp::QoS(10));
-        sub_rgb_info_.subscribe(this, "rgb/camera_info", rclcpp::QoS(10));
+        sub_depth_image_.subscribe(this, topic, hints.getTransport(), rmw_qos_profile_default, sub_options);
+        sub_depth_info_.subscribe(this, "depth/camera_info", rclcpp::QoS(10), sub_options);
+        sub_rgb_info_.subscribe(this, "rgb/camera_info", rclcpp::QoS(10), sub_options);
       }
     };
   // For compressed topics to remap appropriately, we need to pass a

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -142,7 +142,8 @@ RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
         auto node_base = this->get_node_base_interface();
         std::string topic = node_base->resolve_topic_or_service_name("depth/image_rect", false);
         image_transport::TransportHints hints(this, "raw", "depth_image_transport");
-        sub_depth_image_.subscribe(this, topic, hints.getTransport(), rmw_qos_profile_default, sub_options);
+        sub_depth_image_.subscribe(this, topic, hints.getTransport(), rmw_qos_profile_default,
+          sub_options);
         sub_depth_info_.subscribe(this, "depth/camera_info", rclcpp::QoS(10), sub_options);
         sub_rgb_info_.subscribe(this, "rgb/camera_info", rclcpp::QoS(10), sub_options);
       }


### PR DESCRIPTION
> Hi! This is my first PR to ROS2. Please let me know if there are steps I'm missing or additional things you'd like me to check.

This PR adds support to the `depth_image_proc` - `register` node for setting External QoS Configuration on topic _subscriptions_.

## Why?
Sensors are often published with the `SENSOR_DATA` profile, which cannot be read by subscribers expecting the default QoS profile, as the default profile specifies a reliability == reliable requirement. The `SENSOR_DATA` profile uses reliability == best_effort, making these publishers and subscribers incompatible.

Because `depth_image_proc` - `register` does not provide a way to modify the expected QoS of the topic subscriptions, it cannot subscribe to topics published by other nodes which use the `SENSOR_DATA` profile.

ROS2's solution to this common problem is to allow [External QoS Configuration](https://design.ros2.org/articles/qos_configurability.html) through the parameter system. While `depth_image_proc` - `register` supports External QoS Configuration on _published_ topics, it does not support it on _subscribed_ topics.

This PR adds support for External QoS configuration on subscribed topics.

## How?
- Add the same `qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies()` option to all topic subscriptions that is also used on the topic publishers

## Testing
- Compiled on latest pull of ROS2 Rolling
```
$ colcon build --packages-up-to depth_image_proc
Starting >>> tracetools_image_pipeline
Finished <<< tracetools_image_pipeline [0.22s]
Starting >>> image_proc
Finished <<< image_proc [0.58s]
Starting >>> depth_image_proc
Finished <<< depth_image_proc [20.3s]

Summary: 3 packages finished [21.3s]
```

- Compiled and live-tested on ROS2 Jazzy (`jazzy` branch of my fork). This is the same change that was applied to `rolling` 
- Recompiled `depth_image_proc` and launched with QoS remapping arguments using a launch file (on an in-progress robot project):

```
    Node(
            package='depth_image_proc', 
            executable='register_node', 
            name='depth_register',
            parameters=[
                {'qos_overrides./loomo/realsense/color/image_color/camera_info.subscription.reliability': 'best_effort'},
                {'qos_overrides./loomo/realsense/depth/image_depth/camera_info.subscription.reliability': 'best_effort'},
                {'qos_overrides./loomo/realsense/depth/image_depth.subscription.reliability': 'best_effort'},
            ],
            remappings={
                # in
                ('rgb/camera_info', '/loomo/realsense/color/image_color/camera_info'),
                ('depth/camera_info', '/loomo/realsense/depth/image_depth/camera_info'), 
                ('depth/image_rect', '/loomo/realsense/depth/image_depth'),
                # out
                ('depth_registered/camera_info', '/loomo_synthetic/realsense/depth_registered/image_depth/camera_info'),
                ('depth_registered/image_rect', '/loomo_synthetic/realsense/depth_registered/image_depth')
            },
        ),
```

Checked for the presence of new parameters in `rqt_gui`:
![image](https://github.com/user-attachments/assets/b5c20528-a020-4028-a9ad-d2ef37e9bc87)

- Observed that new QoS Parameters for subscribed topics are present and are being set by the launch parameters
- Observed that `depth_image_proc` - `register` is now accepting messages from topics publishing with the `SENSOR_DATA` QoS profile with QoS overrides applied
  