### PR TITLE
`image_view_node`: support bayer images

### DIFF
--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -216,6 +216,11 @@ void ImageViewNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 
     std::string encoding = msg->encoding.empty() ? "bgr8" : msg->encoding;
 
+    // May want to view raw bayer data
+    if (encoding.find("bayer") != std::string::npos) {
+      encoding = "mono8";
+    }
+
     queued_image_.set(
       cv_bridge::cvtColorForDisplay(
         cv_bridge::toCvShare(msg), encoding, options));


### PR DESCRIPTION
so far bayer images always failed with an error:
```
[ERROR] [..] [image_view_node]: Unable to convert 'bayer_rggb8' image for display: 'cv_bridge.cvtColorForDisplay() does not have an output encoding                that is color or mono, and has is bit in depth'
```

the `stereo_view_node` on the other hand already supports bayer images, however it always forcibly converts them to monochrome, even if they are colour images.

for now, this adds the same logic for the single-image viewer and thus only partially resolves #1045.