### PR TITLE
Fix Windows compilation in image_publisher.cpp

### DIFF
--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -31,6 +31,10 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+// This define is added to support M_PI on Windows
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 #include <chrono>
 #include <limits>


### PR DESCRIPTION
PR https://github.com/ros-perception/image_pipeline/pull/985 added some code that used `M_PI`, but `M_PI` is not defined in any standard, and before including `cmath` or `math.h` in Windows it is necessary to define `_USE_MATH_DEFINES` to ensure that `M_PI` is defined.