### PR TITLE
fix depth_image_proc launch files

### DIFF
--- a/depth_image_proc/launch/convert_metric.launch.py
+++ b/depth_image_proc/launch/convert_metric.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/convert_metric.launch.py
+++ b/depth_image_proc/launch/convert_metric.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/convert_metric.launch.py
+++ b/depth_image_proc/launch/convert_metric.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # launch plugin through rclcpp_components container
@@ -69,6 +69,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/crop_foremost.launch.py
+++ b/depth_image_proc/launch/crop_foremost.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         launch_ros.actions.ComposableNodeContainer(

--- a/depth_image_proc/launch/crop_foremost.launch.py
+++ b/depth_image_proc/launch/crop_foremost.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         launch_ros.actions.ComposableNodeContainer(

--- a/depth_image_proc/launch/crop_foremost.launch.py
+++ b/depth_image_proc/launch/crop_foremost.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         launch_ros.actions.ComposableNodeContainer(
@@ -68,6 +68,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/disparity.launch.py
+++ b/depth_image_proc/launch/disparity.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # we use realsense camera for test, realsense not support left and right topic

--- a/depth_image_proc/launch/disparity.launch.py
+++ b/depth_image_proc/launch/disparity.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         # we use realsense camera for test, realsense not support left and right topic

--- a/depth_image_proc/launch/disparity.launch.py
+++ b/depth_image_proc/launch/disparity.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # we use realsense camera for test, realsense not support left and right topic
@@ -72,6 +72,6 @@ def generate_launch_description():
         # TODO: rviz could not display disparity(stereo_msgs)
         # run stereo_view for display after image_view be ported
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyz.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/point_cloud_xyz.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/point_cloud_xyz.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # launch plugin through rclcpp_components container
@@ -69,6 +69,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyz_radial.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # launch plugin through rclcpp_components container
@@ -69,6 +69,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyzi.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message

--- a/depth_image_proc/launch/point_cloud_xyzi.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi.launch.py
@@ -45,7 +45,10 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
+            parameters=[{'align_depth.enable': True},],
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message

--- a/depth_image_proc/launch/point_cloud_xyzi.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message
@@ -71,6 +71,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message,
@@ -72,6 +72,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
@@ -45,7 +45,9 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message,

--- a/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzi_radial.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # NOTE: Realsense camera do not support intensity message,

--- a/depth_image_proc/launch/point_cloud_xyzrgb.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzrgb.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # launch plugin through rclcpp_components container
@@ -71,6 +71,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/launch/point_cloud_xyzrgb.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzrgb.launch.py
@@ -45,7 +45,10 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
+            parameters=[{'align_depth.enable': True},],
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/register.launch.py
+++ b/depth_image_proc/launch/register.launch.py
@@ -45,7 +45,10 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense2_camera', executable='realsense2_camera_node',
+            package='realsense2_camera',
+            executable='realsense2_camera_node',
+            namespace='',
+            parameters=[{'align_depth.enable': True},],
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/register.launch.py
+++ b/depth_image_proc/launch/register.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', executable='realsense_ros2_camera',
+            package='realsense2_camera', executable='realsense2_camera_node',
             output='screen'),
 
         # launch plugin through rclcpp_components container

--- a/depth_image_proc/launch/register.launch.py
+++ b/depth_image_proc/launch/register.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
     return LaunchDescription([
         # install realsense from https://github.com/intel/ros2_intel_realsense
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            package='realsense_ros2_camera', executable='realsense_ros2_camera',
             output='screen'),
 
         # launch plugin through rclcpp_components container
@@ -73,6 +73,6 @@ def generate_launch_description():
 
         # rviz
         launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
+            package='rviz2', executable='rviz2', output='screen',
             arguments=['--display-config', default_rviz]),
     ])

--- a/image_rotate/launch/image_rotate.launch.py
+++ b/image_rotate/launch/image_rotate.launch.py
@@ -37,7 +37,7 @@ import launch_ros.actions
 def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
-            package='image_rotate', node_executable='image_rotate', output='screen',
+            package='image_rotate', executable='image_rotate', output='screen',
             remappings=[('image', '/camera/color/image_raw'),
                         ('camera_info', '/camera/color/camera_info'),
                         ('rotated/image', '/camera/color/image_raw_rotated')]),


### PR DESCRIPTION
A couple of fixes to make the `depth_image_proc` launch files work again. The issues are mostly caused by API with launch and the RealSense node.