### PR TITLE
[depth_image_proc] using sensor data qos profile everywhere

### DIFF
--- a/depth_image_proc/src/convert_metric.cpp
+++ b/depth_image_proc/src/convert_metric.cpp
@@ -76,7 +76,7 @@ ConvertMetricNode::ConvertMetricNode(const rclcpp::NodeOptions & options)
   std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement when SubscriberStatusCallback is available
   // pub_depth_ = it_->advertise("image", 1, connect_cb, connect_cb);
-  pub_depth_ = image_transport::create_publisher(this, "image");
+  pub_depth_ = image_transport::create_publisher(this, "image", rmw_qos_profile_sensor_data);
 }
 
 // Handles (un)subscribing when clients (un)subscribe
@@ -92,7 +92,8 @@ void ConvertMetricNode::connectCb()
     sub_raw_ = image_transport::create_subscription(
       this, "image_raw",
       std::bind(&ConvertMetricNode::depthCb, this, std::placeholders::_1),
-      hints.getTransport());
+      hints.getTransport(),
+      rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/crop_foremost.cpp
+++ b/depth_image_proc/src/crop_foremost.cpp
@@ -81,7 +81,7 @@ CropForemostNode::CropForemostNode(const rclcpp::NodeOptions & options)
   std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement when SubscriberStatusCallback is available
   // pub_depth_ = it_->advertise("image", 1, connect_cb, connect_cb);
-  pub_depth_ = image_transport::create_publisher(this, "image");
+  pub_depth_ = image_transport::create_publisher(this, "image", rmw_qos_profile_sensor_data);
 }
 
 // Handles (un)subscribing when clients (un)subscribe
@@ -97,7 +97,8 @@ void CropForemostNode::connectCb()
     sub_raw_ = image_transport::create_subscription(
       this, "image_raw",
       std::bind(&CropForemostNode::depthCb, this, std::placeholders::_1),
-      hints.getTransport());
+      hints.getTransport(),
+      rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/disparity.cpp
+++ b/depth_image_proc/src/disparity.cpp
@@ -123,8 +123,8 @@ void DisparityNode::connectCb()
     sub_info_.unsubscribe();
   } else if (!sub_depth_image_.getSubscriber()) {
     image_transport::TransportHints hints(this, "raw");
-    sub_depth_image_.subscribe(this, "left/image_rect", hints.getTransport());
-    sub_info_.subscribe(this, "right/camera_info");
+    sub_depth_image_.subscribe(this, "left/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_info_.subscribe(this, "right/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/disparity.cpp
+++ b/depth_image_proc/src/disparity.cpp
@@ -123,7 +123,9 @@ void DisparityNode::connectCb()
     sub_info_.unsubscribe();
   } else if (!sub_depth_image_.getSubscriber()) {
     image_transport::TransportHints hints(this, "raw");
-    sub_depth_image_.subscribe(this, "left/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_image_.subscribe(
+      this, "left/image_rect",
+      hints.getTransport(), rmw_qos_profile_sensor_data);
     sub_info_.subscribe(this, "right/camera_info", rmw_qos_profile_sensor_data);
   }
 }

--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -75,7 +75,7 @@ void PointCloudXyzNode::connectCb()
   if (0) {
     sub_depth_.shutdown();
   } else if (!sub_depth_) {
-    auto custom_qos = rmw_qos_profile_system_default;
+    auto custom_qos = rmw_qos_profile_sensor_data;
     custom_qos.depth = queue_size_;
 
     sub_depth_ = image_transport::create_camera_subscription(

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -98,12 +98,12 @@ void PointCloudXyziNode::connectCb()
 
     // depth image can use different transport.(e.g. compressedDepth)
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
-    sub_depth_.subscribe(this, "depth/image_rect", depth_hints.getTransport());
+    sub_depth_.subscribe(this, "depth/image_rect", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // intensity uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_intensity_.subscribe(this, "intensity/image_rect", hints.getTransport());
-    sub_info_.subscribe(this, "intensity/camera_info");
+    sub_intensity_.subscribe(this, "intensity/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_info_.subscribe(this, "intensity/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -98,11 +98,15 @@ void PointCloudXyziNode::connectCb()
 
     // depth image can use different transport.(e.g. compressedDepth)
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
-    sub_depth_.subscribe(this, "depth/image_rect", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_.subscribe(
+      this, "depth/image_rect",
+      depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // intensity uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_intensity_.subscribe(this, "intensity/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_intensity_.subscribe(
+      this, "intensity/image_rect",
+      hints.getTransport(), rmw_qos_profile_sensor_data);
     sub_info_.subscribe(this, "intensity/camera_info", rmw_qos_profile_sensor_data);
   }
 }

--- a/depth_image_proc/src/point_cloud_xyzi_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi_radial.cpp
@@ -100,12 +100,12 @@ void PointCloudXyziRadialNode::connectCb()
 
     // depth image can use different transport.(e.g. compressedDepth)
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
-    sub_depth_.subscribe(this, "depth/image_raw", depth_hints.getTransport());
+    sub_depth_.subscribe(this, "depth/image_raw", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // intensity uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_intensity_.subscribe(this, "intensity/image_raw", hints.getTransport());
-    sub_info_.subscribe(this, "intensity/camera_info");
+    sub_intensity_.subscribe(this, "intensity/image_raw", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_info_.subscribe(this, "intensity/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/point_cloud_xyzi_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi_radial.cpp
@@ -100,11 +100,15 @@ void PointCloudXyziRadialNode::connectCb()
 
     // depth image can use different transport.(e.g. compressedDepth)
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
-    sub_depth_.subscribe(this, "depth/image_raw", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_.subscribe(
+      this, "depth/image_raw",
+      depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // intensity uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_intensity_.subscribe(this, "intensity/image_raw", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_intensity_.subscribe(
+      this, "intensity/image_raw",
+      hints.getTransport(), rmw_qos_profile_sensor_data);
     sub_info_.subscribe(this, "intensity/camera_info", rmw_qos_profile_sensor_data);
   }
 }

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -123,14 +123,14 @@ void PointCloudXyzrgbNode::connectCb()
     // depth image can use different transport.(e.g. compressedDepth)
     sub_depth_.subscribe(
       this, "depth_registered/image_rect",
-      depth_hints.getTransport(), rmw_qos_profile_default, sub_opts);
+      depth_hints.getTransport(), rmw_qos_profile_sensor_data, sub_opts);
 
     // rgb uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
     sub_rgb_.subscribe(
       this, "rgb/image_rect_color",
-      hints.getTransport(), rmw_qos_profile_default, sub_opts);
-    sub_info_.subscribe(this, "rgb/camera_info");
+      hints.getTransport(), rmw_qos_profile_sensor_data, sub_opts);
+    sub_info_.subscribe(this, "rgb/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
@@ -115,12 +115,12 @@ void PointCloudXyzrgbRadialNode::connectCb()
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
 
     // depth image can use different transport.(e.g. compressedDepth)
-    sub_depth_.subscribe(this, "depth_registered/image_rect", depth_hints.getTransport());
+    sub_depth_.subscribe(this, "depth_registered/image_rect", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // rgb uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_rgb_.subscribe(this, "rgb/image_rect_color", hints.getTransport());
-    sub_info_.subscribe(this, "rgb/camera_info");
+    sub_rgb_.subscribe(this, "rgb/image_rect_color", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_info_.subscribe(this, "rgb/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 

--- a/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
@@ -115,11 +115,15 @@ void PointCloudXyzrgbRadialNode::connectCb()
     image_transport::TransportHints depth_hints(this, "raw", depth_image_transport_param);
 
     // depth image can use different transport.(e.g. compressedDepth)
-    sub_depth_.subscribe(this, "depth_registered/image_rect", depth_hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_.subscribe(
+      this, "depth_registered/image_rect",
+      depth_hints.getTransport(), rmw_qos_profile_sensor_data);
 
     // rgb uses normal ros transport hints.
     image_transport::TransportHints hints(this, "raw");
-    sub_rgb_.subscribe(this, "rgb/image_rect_color", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_rgb_.subscribe(
+      this, "rgb/image_rect_color",
+      hints.getTransport(), rmw_qos_profile_sensor_data);
     sub_info_.subscribe(this, "rgb/camera_info", rmw_qos_profile_sensor_data);
   }
 }

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -132,7 +132,7 @@ RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
   // pub_registered_ = it_depth_reg.advertiseCamera("image_rect", 1,
   //                                               image_connect_cb, image_connect_cb,
   //                                               info_connect_cb, info_connect_cb);
-  pub_registered_ = image_transport::create_camera_publisher(this, "depth_registered/image_rect");
+  pub_registered_ = image_transport::create_camera_publisher(this, "depth_registered/image_rect", rmw_qos_profile_sensor_data);
 }
 
 // Handles (un)subscribing when clients (un)subscribe
@@ -147,9 +147,9 @@ void RegisterNode::connectCb()
     sub_rgb_info_.unsubscribe();
   } else if (!sub_depth_image_.getSubscriber()) {
     image_transport::TransportHints hints(this, "raw");
-    sub_depth_image_.subscribe(this, "depth/image_rect", hints.getTransport());
-    sub_depth_info_.subscribe(this, "depth/camera_info");
-    sub_rgb_info_.subscribe(this, "rgb/camera_info");
+    sub_depth_image_.subscribe(this, "depth/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_info_.subscribe(this, "depth/camera_info", rmw_qos_profile_sensor_data);
+    sub_rgb_info_.subscribe(this, "rgb/camera_info", rmw_qos_profile_sensor_data);
   }
 }
 
@@ -191,6 +191,7 @@ void RegisterNode::imageCb(
   registered_msg->height = resolution.height;
   registered_msg->width = resolution.width;
   // step and data set in convert(), depend on depth data type
+
 
   if (depth_image_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
     convert<uint16_t>(depth_image_msg, registered_msg, depth_to_rgb);

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -132,7 +132,9 @@ RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
   // pub_registered_ = it_depth_reg.advertiseCamera("image_rect", 1,
   //                                               image_connect_cb, image_connect_cb,
   //                                               info_connect_cb, info_connect_cb);
-  pub_registered_ = image_transport::create_camera_publisher(this, "depth_registered/image_rect", rmw_qos_profile_sensor_data);
+  pub_registered_ = image_transport::create_camera_publisher(
+    this, "depth_registered/image_rect",
+    rmw_qos_profile_sensor_data);
 }
 
 // Handles (un)subscribing when clients (un)subscribe
@@ -147,7 +149,9 @@ void RegisterNode::connectCb()
     sub_rgb_info_.unsubscribe();
   } else if (!sub_depth_image_.getSubscriber()) {
     image_transport::TransportHints hints(this, "raw");
-    sub_depth_image_.subscribe(this, "depth/image_rect", hints.getTransport(), rmw_qos_profile_sensor_data);
+    sub_depth_image_.subscribe(
+      this, "depth/image_rect",
+      hints.getTransport(), rmw_qos_profile_sensor_data);
     sub_depth_info_.subscribe(this, "depth/camera_info", rmw_qos_profile_sensor_data);
     sub_rgb_info_.subscribe(this, "rgb/camera_info", rmw_qos_profile_sensor_data);
   }


### PR DESCRIPTION
In `depth_image_proc`, some publishers are already set to use sensor data QoS; however, this is not in place for all of them, nor is for any subscriber.

This PR aims at changing the QoS profile for those publishers and subscribers that are still using the default one, in order to have all of them set to use a sensor data QoS.