### PR TITLE
Replace OpenCV version string comparison with semver.

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -39,6 +39,7 @@ import numpy.linalg
 import sensor_msgs.msg
 import tarfile
 from enum import Enum
+from semver import VersionInfo
 
 # Supported camera models
 
@@ -90,7 +91,7 @@ class ChessboardInfo():
                 "7x7_100": cv2.aruco.DICT_7X7_100,
                 "7x7_250": cv2.aruco.DICT_7X7_250,
                 "7x7_1000": cv2.aruco.DICT_7X7_1000}[aruco_dict])
-            if cv2.__version__ >= '4.8.0':
+            if VersionInfo.parse(cv2.__version__) >= VersionInfo.parse('4.8.0'):
                 self.charuco_board = cv2.aruco.CharucoBoard(
                     (self.n_cols, self.n_rows),
                     self.dim, self.marker_size, self.aruco_dict)
@@ -296,7 +297,7 @@ def _get_charuco_corners(img, board, refine):
     else:
         mono = img
 
-    if cv2.__version__ >= '4.8.0':
+    if VersionInfo.parse(cv2.__version__) >= VersionInfo.parse('4.8.0'):
         charucodetector = cv2.aruco.CharucoDetector(board.charuco_board)
         square_corners, ids, marker_corners, marker_ids = charucodetector.detectBoard(
             mono)


### PR DESCRIPTION
When using the ChArUco markers with `cameracalibrator`, I found out that there's an issue with the last versions of OpenCV due to the fact that versions are compared as strings and the thing goes wrong for versions 4.10 and above e.g.:
```
>>> '4.7.0' >= '4.8.0'
False
>>> '4.8.0' >= '4.8.0'
True
>>> '4.9.0' >= '4.8.0'
True
>>> '4.10.0' >= '4.8.0'
False
>>> '4.11.0' >= '4.8.0'
False
```

I fixed the behavior by using `semver` library which is already used in the package e.g.:
```
>>> VersionInfo.parse('4.7.0') >= VersionInfo.parse('4.8.0')
False
>>> VersionInfo.parse('4.8.0') >= VersionInfo.parse('4.8.0')
True
>>> VersionInfo.parse('4.9.0') >= VersionInfo.parse('4.8.0')
True
>>> VersionInfo.parse('4.10.0') >= VersionInfo.parse('4.8.0')
True
>>> VersionInfo.parse('4.11.0') >= VersionInfo.parse('4.8.0')
True
```

Hope this fix helps anyone else too despite the fact that documentation/tutorials are skipping to mention the ChArUcos as a possible pattern (like [here](https://docs.ros.org/en/rolling/p/camera_calibration/doc/index.html)). In my experience, ChArUcos give better results than classic chessboards.

Also a question: does anyone mind if I cherry-pick [this fix here](https://github.com/ros-perception/image_pipeline/pull/979/files) along with mine above also to the humble?