### PR TITLE
fix colour channel order for "rgb8" in image_view

### DIFF
--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -218,7 +218,7 @@ void ImageViewNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 
     // OpenCV uses BGR colour channel order
     if (encoding.find("rgb8") != std::string::npos) {
-        encoding = "bgr8";
+      encoding = "bgr8";
     }
 
     // May want to view raw bayer data

--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -216,6 +216,11 @@ void ImageViewNode::imageCb(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 
     std::string encoding = msg->encoding.empty() ? "bgr8" : msg->encoding;
 
+    // OpenCV uses BGR colour channel order
+    if (encoding.find("rgb8") != std::string::npos) {
+        encoding = "bgr8";
+    }
+
     // May want to view raw bayer data
     if (encoding.find("bayer") != std::string::npos) {
       encoding = "mono8";


### PR DESCRIPTION
Previously, a `rgb8` encoding was just visualised in RGB colour channel order via OpenCV, which expects colour channel order BGR. Fix this by converting from RGB to BGR.