### PR TITLE
Update index.ros.org package website links

### DIFF
--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -14,7 +14,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/camera_calibration/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/camera_calibration/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>James Bowman</author>

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -19,7 +19,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/depth_image_proc/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/depth_image_proc/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_pipeline/package.xml
+++ b/image_pipeline/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/image_pipeline/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/image_pipeline/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_proc/package.xml
+++ b/image_proc/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/image_proc/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/image_proc/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/image_publisher/package.xml
+++ b/image_publisher/package.xml
@@ -17,7 +17,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/image_publisher/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/image_publisher/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Kei Okada</author>

--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -30,7 +30,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/image_rotate/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/image_rotate/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Blaise Gassend</author>

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -14,7 +14,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/image_view/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/image_view/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>

--- a/stereo_image_proc/package.xml
+++ b/stereo_image_proc/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>
 
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/stereo_image_proc/github-ros-perception-image_pipeline/</url>
+  <url type="website">https://index.ros.org/p/stereo_image_proc/</url>
   <url type="bugtracker">https://github.com/ros-perception/image_pipeline/issues</url>
   <url type="repository">https://github.com/ros-perception/image_pipeline</url>
   <author>Patrick Mihelich</author>


### PR DESCRIPTION
Fixes https://github.com/ros-infrastructure/rosindex/issues/539

`index.ros.org/p/$pkg/` links with the GitHub repo at the end no longer work and result in a 404.

This should be backported to all non-EOL distro branches.