### PR TITLE
fix remapping bug in RectifyNode

### DIFF
--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -59,6 +59,9 @@ RectifyNode::RectifyNode(const rclcpp::NodeOptions & options)
   // fully expanded and remapped topic name to image_transport
   auto node_base = this->get_node_base_interface();
   image_topic_ = node_base->resolve_topic_or_service_name("image", false);
+  std::string rect_topic =
+    node_base->resolve_topic_or_service_name("image_rect", false);
+
 
   queue_size_ = this->declare_parameter("queue_size", 5);
   interpolation_ = this->declare_parameter("interpolation", 1);
@@ -83,7 +86,7 @@ RectifyNode::RectifyNode(const rclcpp::NodeOptions & options)
 
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_rect_ = image_transport::create_publisher(this, "image_rect", rmw_qos_profile_default,
+  pub_rect_ = image_transport::create_publisher(this, rect_topic, rmw_qos_profile_default,
       pub_options);
 }
 


### PR DESCRIPTION
The previous effort to fix remapping issues (https://github.com/ros-perception/image_pipeline/issues/940), addressed by pull request (https://github.com/ros-perception/image_pipeline/pull/941), overlooked the RectifyNode.