### PR TITLE
Support new image_transport API and fix deprecation warnings

### DIFF
--- a/image_proc/src/crop_decimate.cpp
+++ b/image_proc/src/crop_decimate.cpp
@@ -144,9 +144,9 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
       } else if (!sub_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_ = image_transport::create_camera_subscription(
-          this, image_topic_, std::bind(
+          *this, image_topic_, std::bind(
             &CropDecimateNode::imageCb, this,
             std::placeholders::_1, std::placeholders::_2), hints.getTransport(), qos_profile);
       }
@@ -154,7 +154,7 @@ CropDecimateNode::CropDecimateNode(const rclcpp::NodeOptions & options)
 
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_ = image_transport::create_camera_publisher(this, pub_topic, rclcpp::SystemDefaultsQoS(),
+  pub_ = image_transport::create_camera_publisher(*this, pub_topic, rclcpp::SystemDefaultsQoS(),
       pub_options);
 }
 

--- a/image_proc/src/crop_non_zero.cpp
+++ b/image_proc/src/crop_non_zero.cpp
@@ -72,9 +72,9 @@ CropNonZeroNode::CropNonZeroNode(const rclcpp::NodeOptions & options)
       } else if (!sub_raw_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_raw_ = image_transport::create_subscription(
-          this, image_topic_, std::bind(
+          *this, image_topic_, std::bind(
             &CropNonZeroNode::imageCb, this,
             std::placeholders::_1), hints.getTransport(), qos_profile);
       }
@@ -82,7 +82,7 @@ CropNonZeroNode::CropNonZeroNode(const rclcpp::NodeOptions & options)
 
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_ = image_transport::create_publisher(this, pub_topic, rclcpp::SystemDefaultsQoS(),
+  pub_ = image_transport::create_publisher(*this, pub_topic, rclcpp::SystemDefaultsQoS(),
     pub_options);
 }
 

--- a/image_proc/src/debayer.cpp
+++ b/image_proc/src/debayer.cpp
@@ -75,9 +75,9 @@ DebayerNode::DebayerNode(const rclcpp::NodeOptions & options)
       } else if (!sub_raw_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_raw_ = image_transport::create_subscription(
-          this, image_topic_,
+          *this, image_topic_,
           std::bind(
             &DebayerNode::imageCb, this,
             std::placeholders::_1), hints.getTransport(), qos_profile);
@@ -86,9 +86,9 @@ DebayerNode::DebayerNode(const rclcpp::NodeOptions & options)
 
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_mono_ = image_transport::create_publisher(this, mono_topic, rclcpp::SystemDefaultsQoS(),
+  pub_mono_ = image_transport::create_publisher(*this, mono_topic, rclcpp::SystemDefaultsQoS(),
       pub_options);
-  pub_color_ = image_transport::create_publisher(this, color_topic, rclcpp::SystemDefaultsQoS(),
+  pub_color_ = image_transport::create_publisher(*this, color_topic, rclcpp::SystemDefaultsQoS(),
       pub_options);
 }
 

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -76,9 +76,9 @@ RectifyNode::RectifyNode(const rclcpp::NodeOptions & options)
       } else if (!sub_camera_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_camera_ = image_transport::create_camera_subscription(
-          this, image_topic_, std::bind(
+          *this, image_topic_, std::bind(
             &RectifyNode::imageCb,
             this, std::placeholders::_1, std::placeholders::_2), hints.getTransport(), qos_profile);
       }
@@ -86,7 +86,7 @@ RectifyNode::RectifyNode(const rclcpp::NodeOptions & options)
 
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_rect_ = image_transport::create_publisher(this, rect_topic, rclcpp::SystemDefaultsQoS(),
+  pub_rect_ = image_transport::create_publisher(*this, rect_topic, rclcpp::SystemDefaultsQoS(),
       pub_options);
 }
 

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -79,9 +79,9 @@ ResizeNode::ResizeNode(const rclcpp::NodeOptions & options)
       } else if (!sub_image_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_image_ = image_transport::create_camera_subscription(
-          this, image_topic_,
+          *this, image_topic_,
           std::bind(
             &ResizeNode::imageCb, this,
             std::placeholders::_1,
@@ -92,7 +92,7 @@ ResizeNode::ResizeNode(const rclcpp::NodeOptions & options)
   // Create publisher - allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   pub_image_ =
-    image_transport::create_camera_publisher(this, pub_topic, rclcpp::SystemDefaultsQoS(),
+    image_transport::create_camera_publisher(*this, pub_topic, rclcpp::SystemDefaultsQoS(),
       pub_options);
 }
 

--- a/image_proc/src/track_marker.cpp
+++ b/image_proc/src/track_marker.cpp
@@ -87,9 +87,9 @@ TrackMarkerNode::TrackMarkerNode(const rclcpp::NodeOptions & options)
       } else if (!sub_camera_) {
         // Create subscriber with QoS matched to subscribed topic publisher
         auto qos_profile = getQosProfile(this, image_topic_);
-        image_transport::TransportHints hints(this);
+        image_transport::TransportHints hints(*this);
         sub_camera_ = image_transport::create_camera_subscription(
-          this, image_topic_, std::bind(
+          *this, image_topic_, std::bind(
             &TrackMarkerNode::imageCb,
             this, std::placeholders::_1, std::placeholders::_2),
           hints.getTransport(), qos_profile);

--- a/image_proc/test/rostest.cpp
+++ b/image_proc/test/rostest.cpp
@@ -80,7 +80,7 @@ protected:
     }
 
     // Create raw camera publisher
-    image_transport::ImageTransport it(this->node);
+    image_transport::ImageTransport it(*(this->node));
     cam_pub = it.advertiseCamera(topic_raw, 1);
 
     while (true) {
@@ -128,9 +128,11 @@ TEST_F(ImageProcTest, monoSubscription)
   RCLCPP_INFO(node->get_logger(), "Publishing");
 
   RCLCPP_INFO(node->get_logger(), "Spinning");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (!has_new_image_) {
     publishRaw();
-    rclcpp::spin_some(node);
+    executor.spin_some();
   }
   rclcpp::shutdown();
   RCLCPP_INFO(node->get_logger(), "Done");

--- a/image_proc/test/test_rectify.cpp
+++ b/image_proc/test/test_rectify.cpp
@@ -145,7 +145,7 @@ protected:
       });
 
     // Create raw camera subscriber and publisher
-    image_transport::ImageTransport it(node);
+    image_transport::ImageTransport it(*node);
     cam_pub_ = it.advertiseCamera(topic_raw_, 1);
   }
 
@@ -194,7 +194,7 @@ public:
 TEST_F(ImageProcRectifyTest, rectifyTest)
 {
   RCLCPP_INFO(node->get_logger(), "In test. Subscribing.");
-  image_transport::ImageTransport it(node);
+  image_transport::ImageTransport it(*node);
   cam_sub_ = it.subscribe(
     topic_rect_, rclcpp::SensorDataQoS(),
     &ImageProcRectifyTest::imageCallback,
@@ -228,8 +228,10 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
 
   // use original cam_info
   publishRaw();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -247,7 +249,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -259,7 +261,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -271,7 +273,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 

--- a/image_publisher/src/image_publisher.cpp
+++ b/image_publisher/src/image_publisher.cpp
@@ -66,7 +66,7 @@ ImagePublisher::ImagePublisher(
   std::string topic_name = node_base->resolve_topic_or_service_name("image_raw", false);
   rclcpp::PublisherOptions pub_options;
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  pub_ = image_transport::create_camera_publisher(this, topic_name, rclcpp::SystemDefaultsQoS(),
+  pub_ = image_transport::create_camera_publisher(*this, topic_name, rclcpp::SystemDefaultsQoS(),
       pub_options);
 
   field_of_view_ = this->declare_parameter("field_of_view", static_cast<double>(0));
@@ -137,7 +137,15 @@ void ImagePublisher::reconfigureCallback()
     std::chrono::milliseconds(static_cast<int>(1000 / publish_rate_)),
     std::bind(&ImagePublisher::doWork, this));
 
-  camera_info_manager::CameraInfoManager c(this);
+  camera_info_manager::CameraInfoManager c(
+    this->get_node_base_interface(),
+    this->get_node_services_interface(),
+    this->get_node_logging_interface(),
+    "camera",
+    "",
+    rclcpp::SystemDefaultsQoS(),
+    "~"
+  );
   if (!camera_info_url_.empty()) {
     RCLCPP_INFO(get_logger(), "camera_info_url: %s", camera_info_url_.c_str());
     try {

--- a/image_rotate/src/image_flip.cpp
+++ b/image_rotate/src/image_flip.cpp
@@ -213,13 +213,13 @@ void ImageFlipNode::onInit()
         }
 
         // This will check image_transport parameter to get proper transport
-        image_transport::TransportHints transport_hint(this, "raw");
+        image_transport::TransportHints transport_hint(*this, "raw");
 
         if (config_.use_camera_info) {
           auto custom_qos = rclcpp::SystemDefaultsQoS();
           custom_qos.keep_last(3);
           cam_sub_ = image_transport::create_camera_subscription(
-            this,
+            *this,
             topic_name,
             std::bind(
               &ImageFlipNode::imageCallbackWithInfo, this,
@@ -230,7 +230,7 @@ void ImageFlipNode::onInit()
           auto custom_qos = rclcpp::SystemDefaultsQoS();
           custom_qos.keep_last(3);
           img_sub_ = image_transport::create_subscription(
-            this,
+            *this,
             topic_name,
             std::bind(&ImageFlipNode::imageCallback, this, std::placeholders::_1),
             transport_hint.getTransport(),
@@ -246,9 +246,9 @@ void ImageFlipNode::onInit()
 
   auto custom_qos = rclcpp::SystemDefaultsQoS();
   if (config_.use_camera_info) {
-    cam_pub_ = image_transport::create_camera_publisher(this, topic, custom_qos, pub_options);
+    cam_pub_ = image_transport::create_camera_publisher(*this, topic, custom_qos, pub_options);
   } else {
-    img_pub_ = image_transport::create_publisher(this, topic, custom_qos, pub_options);
+    img_pub_ = image_transport::create_publisher(*this, topic, custom_qos, pub_options);
   }
 
   tf_pub_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*this);

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -318,7 +318,7 @@ void ImageRotateNode::onInit()
           auto custom_qos = rclcpp::SystemDefaultsQoS();
           custom_qos.keep_last(3);
           cam_sub_ = image_transport::create_camera_subscription(
-            this,
+            *this,
             topic_name,
             std::bind(
               &ImageRotateNode::imageCallbackWithInfo, this,
@@ -329,7 +329,7 @@ void ImageRotateNode::onInit()
           auto custom_qos = rclcpp::SystemDefaultsQoS();
           custom_qos.keep_last(3);
           img_sub_ = image_transport::create_subscription(
-            this,
+            *this,
             topic_name,
             std::bind(&ImageRotateNode::imageCallback, this, std::placeholders::_1),
             transport_hint.getTransport(),
@@ -345,7 +345,7 @@ void ImageRotateNode::onInit()
 
   // Allow overriding QoS settings (history, depth, reliability)
   pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  img_pub_ = image_transport::create_publisher(this, topic, rclcpp::SystemDefaultsQoS(),
+  img_pub_ = image_transport::create_publisher(*this, topic, rclcpp::SystemDefaultsQoS(),
     pub_options);
 }
 

--- a/image_view/src/extract_images_node.cpp
+++ b/image_view/src/extract_images_node.cpp
@@ -76,11 +76,11 @@ ExtractImagesNode::ExtractImagesNode(const rclcpp::NodeOptions & options)
 
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", "raw");
-  image_transport::TransportHints hints(this);
+  image_transport::TransportHints hints(*this);
   std::string transport = this->get_parameter("transport").as_string();
 
   sub_ = image_transport::create_subscription(
-    this, topic, std::bind(
+    *this, topic, std::bind(
       &ExtractImagesNode::image_cb, this, std::placeholders::_1),
     hints.getTransport(), rclcpp::SensorDataQoS());
 

--- a/image_view/src/image_saver_node.cpp
+++ b/image_view/src/image_saver_node.cpp
@@ -74,7 +74,7 @@ ImageSaverNode::ImageSaverNode(const rclcpp::NodeOptions & options)
 {
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", "raw");
-  image_transport::TransportHints hints(this);
+  image_transport::TransportHints hints(*this);
 
   // For compressed topics to remap appropriately, we need to pass a
   // fully expanded and remapped topic name to image_transport
@@ -83,13 +83,13 @@ ImageSaverNode::ImageSaverNode(const rclcpp::NodeOptions & options)
 
   // Useful when CameraInfo is being published
   cam_sub_ = image_transport::create_camera_subscription(
-    this, topic, std::bind(
+    *this, topic, std::bind(
       &ImageSaverNode::callbackWithCameraInfo, this, std::placeholders::_1, std::placeholders::_2),
     hints.getTransport(), rclcpp::SensorDataQoS());
 
   // Useful when CameraInfo is not being published
   image_sub_ = image_transport::create_subscription(
-    this, topic, std::bind(
+    *this, topic, std::bind(
       &ImageSaverNode::callbackWithoutCameraInfo, this, std::placeholders::_1),
     hints.getTransport(), rclcpp::SystemDefaultsQoS());
 

--- a/image_view/src/image_view_node.cpp
+++ b/image_view/src/image_view_node.cpp
@@ -107,7 +107,7 @@ ImageViewNode::ImageViewNode(const rclcpp::NodeOptions & options)
 {
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", "raw");
-  image_transport::TransportHints hints(this);
+  image_transport::TransportHints hints(*this);
   RCLCPP_INFO(this->get_logger(), "Using transport \"%s\"", hints.getTransport().c_str());
 
   // For compressed topics to remap appropriately, we need to pass a
@@ -117,7 +117,7 @@ ImageViewNode::ImageViewNode(const rclcpp::NodeOptions & options)
 
   pub_ = this->create_publisher<sensor_msgs::msg::Image>("output", 1);
   sub_ = image_transport::create_subscription(
-    this, topic, std::bind(&ImageViewNode::imageCb, this, std::placeholders::_1),
+    *this, topic, std::bind(&ImageViewNode::imageCb, this, std::placeholders::_1),
     hints.getTransport(), rclcpp::SensorDataQoS());
 
   auto topics = this->get_topic_names_and_types();

--- a/image_view/src/stereo_view_node.cpp
+++ b/image_view/src/stereo_view_node.cpp
@@ -99,7 +99,7 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
 
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", std::string("raw"));
-  image_transport::TransportHints hints(this);
+  image_transport::TransportHints hints(*this);
 
   // Do GUI window setup
   int flags = autosize ? (cv::WINDOW_AUTOSIZE | cv::WINDOW_KEEPRATIO | cv::WINDOW_GUI_EXPANDED) : 0;
@@ -128,9 +128,9 @@ StereoViewNode::StereoViewNode(const rclcpp::NodeOptions & options)
     stereo_ns + "/disparity", this->get_name(), this->get_namespace());
 
   // Subscribe to three input topics.
-  left_sub_.subscribe(this, left_topic, hints.getTransport(), rclcpp::SystemDefaultsQoS());
-  right_sub_.subscribe(this, right_topic, hints.getTransport(), rclcpp::SystemDefaultsQoS());
-  disparity_sub_.subscribe(this, disparity_topic, rclcpp::QoS(10));
+  left_sub_.subscribe(*this, left_topic, hints.getTransport(), rclcpp::SystemDefaultsQoS());
+  right_sub_.subscribe(*this, right_topic, hints.getTransport(), rclcpp::SystemDefaultsQoS());
+  disparity_sub_.subscribe(*this, disparity_topic, rclcpp::QoS(10));
 
   RCLCPP_INFO(
     this->get_logger(),

--- a/image_view/src/video_recorder_node.cpp
+++ b/image_view/src/video_recorder_node.cpp
@@ -68,7 +68,7 @@ VideoRecorderNode::VideoRecorderNode(const rclcpp::NodeOptions & options)
 
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", "raw");
-  image_transport::TransportHints hints(this);
+  image_transport::TransportHints hints(*this);
 
   // For compressed topics to remap appropriately, we need to pass a
   // fully expanded and remapped topic name to image_transport
@@ -76,7 +76,7 @@ VideoRecorderNode::VideoRecorderNode(const rclcpp::NodeOptions & options)
   std::string topic = node_base->resolve_topic_or_service_name("image", false);
 
   sub_image = image_transport::create_subscription(
-    this, topic, std::bind(
+    *this, topic, std::bind(
       &VideoRecorderNode::callback, this,
       std::placeholders::_1), hints.getTransport(),
       rclcpp::SystemDefaultsQoS());


### PR DESCRIPTION
Fix #1113 by adapting to new `image_transport` APIs and also addresses other deprecation warnings from https://github.com/ros2/rclcpp/pull/2848

Supersedes https://github.com/ros-perception/image_pipeline/pull/1099 