### PR TITLE
Removed deprecation warning rclcpp::spin_some

### DIFF
--- a/image_proc/test/rostest.cpp
+++ b/image_proc/test/rostest.cpp
@@ -128,9 +128,11 @@ TEST_F(ImageProcTest, monoSubscription)
   RCLCPP_INFO(node->get_logger(), "Publishing");
 
   RCLCPP_INFO(node->get_logger(), "Spinning");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (!has_new_image_) {
     publishRaw();
-    rclcpp::spin_some(node);
+    executor.spin_some();
   }
   rclcpp::shutdown();
   RCLCPP_INFO(node->get_logger(), "Done");

--- a/image_proc/test/test_rectify.cpp
+++ b/image_proc/test/test_rectify.cpp
@@ -228,8 +228,10 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
 
   // use original cam_info
   publishRaw();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -247,7 +249,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -259,7 +261,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 
@@ -271,7 +273,7 @@ TEST_F(ImageProcRectifyTest, rectifyTest)
   publishRaw();
 
   while (!has_new_image_) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 


### PR DESCRIPTION
Related with this comment https://github.com/ros-perception/image_pipeline/pull/1114#issuecomment-3294547200