### PR TITLE
Fix incorrect plugin name for PointCloudXyzrgbRadialNode

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -70,7 +70,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE point_cloud_xyzi_radial_node
 )
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "depth_image_proc::PointCloudXyziRadialNode"
+  PLUGIN "depth_image_proc::PointCloudXyzrgbRadialNode"
   EXECUTABLE point_cloud_xyzrgb_radial_node
 )
 rclcpp_components_register_node(${PROJECT_NAME}


### PR DESCRIPTION
Hi, the plugin `PointCloudXyzrgbRadialNode` is incorrectly registered as `PointCloudXyziRadialNode`, this PR fixes the issue