### PR TITLE
Possibility to set SensorData QoS for subscribers (image_pipeline/image_rotate)

### DIFF
--- a/image_rotate/include/image_rotate/image_rotate_node.hpp
+++ b/image_rotate/include/image_rotate/image_rotate_node.hpp
@@ -66,6 +66,7 @@ struct ImageRotateConfig
   bool use_camera_info;
   double max_angular_rate;
   double output_image_size;
+  std::string custom_qos_type;
 };
 
 class ImageRotateNode : public rclcpp::Node

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -316,13 +316,13 @@ void ImageRotateNode::onInit()
         image_transport::TransportHints transport_hint(*this,
           "raw");
 
-        rclcpp::QoS custom_qos = rclcpp::SystemDefaultsQoS();
+        auto custom_qos = rclcpp::SystemDefaultsQoS();
         if (config_.custom_qos_type == "sensor_data") {
-            custom_qos = rclcpp::SensorDataQoS();
-            custom_qos.keep_last(3);
+          custom_qos = rclcpp::SensorDataQoS();
+          custom_qos.keep_last(3);
         } else if (config_.custom_qos_type == "default") {
-            custom_qos = rclcpp::SystemDefaultsQoS();
-            custom_qos.keep_last(3);
+          custom_qos = rclcpp::SystemDefaultsQoS();
+          custom_qos.keep_last(3);
         }
 
         if (config_.use_camera_info && config_.input_frame_id.empty()) {

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -127,6 +127,7 @@ ImageRotateNode::ImageRotateNode(const rclcpp::NodeOptions & options)
   config_.use_camera_info = this->declare_parameter("use_camera_info", true);
   config_.max_angular_rate = this->declare_parameter("max_angular_rate", 10.0);
   config_.output_image_size = this->declare_parameter("output_image_size", 2.0);
+  config_.custom_qos_type = this->declare_parameter("custom_qos_type", std::string("default"));
 
   // TransportHints does not actually declare the parameter
   this->declare_parameter<std::string>("image_transport", "raw");
@@ -315,9 +316,14 @@ void ImageRotateNode::onInit()
         image_transport::TransportHints transport_hint(*this,
           "raw");
 
+        rclcpp::QoS custom_qos = rclcpp::SystemDefaultsQoS();
+        if (config_.custom_qos_type == "sensor_data") {
+            custom_qos = rclcpp::SensorDataQoS();
+        } else if (config_.custom_qos_type == "default") {
+            custom_qos = rclcpp::SystemDefaultsQoS();
+        }
+        
         if (config_.use_camera_info && config_.input_frame_id.empty()) {
-          auto custom_qos = rclcpp::SystemDefaultsQoS();
-          custom_qos.keep_last(3);
           cam_sub_ = image_transport::create_camera_subscription(
             *this,
             topic_name,
@@ -327,8 +333,6 @@ void ImageRotateNode::onInit()
             transport_hint.getTransport(),
             custom_qos);
         } else {
-          auto custom_qos = rclcpp::SystemDefaultsQoS();
-          custom_qos.keep_last(3);
           img_sub_ = image_transport::create_subscription(
             *this,
             topic_name,

--- a/image_rotate/src/image_rotate_node.cpp
+++ b/image_rotate/src/image_rotate_node.cpp
@@ -319,10 +319,12 @@ void ImageRotateNode::onInit()
         rclcpp::QoS custom_qos = rclcpp::SystemDefaultsQoS();
         if (config_.custom_qos_type == "sensor_data") {
             custom_qos = rclcpp::SensorDataQoS();
+            custom_qos.keep_last(3);
         } else if (config_.custom_qos_type == "default") {
             custom_qos = rclcpp::SystemDefaultsQoS();
+            custom_qos.keep_last(3);
         }
-        
+
         if (config_.use_camera_info && config_.input_frame_id.empty()) {
           cam_sub_ = image_transport::create_camera_subscription(
             *this,


### PR DESCRIPTION
In many applications it may be needed to have subscribers using sensor data QoS. 
In `image_rotate` some publisher already expose the qos parameter to be overridden. 

It may be useful having a parameter which allows users to set the sensor data QoS for the subscriber, leaving the SystemDefault one as default value.

Example of output: 

```
ros2 run image_rotate image_rotate --ros-args -p custom_qos_type:=sensor_data
[INFO] [1764844207.285357103] [ImageRotateNode]: Reset target_x as '0.000000'
[INFO] [1764844207.285397973] [ImageRotateNode]: Reset target_y as '0.000000'
[INFO] [1764844207.285408258] [ImageRotateNode]: Reset target_z as '1.000000'
[INFO] [1764844207.285424141] [ImageRotateNode]: Reset source_x as '0.000000'
[INFO] [1764844207.285432671] [ImageRotateNode]: Reset source_y as '-1.000000'
[INFO] [1764844207.285442329] [ImageRotateNode]: Reset source_z as '0.000000'
```

```
ros2 param dump /ImageRotateNode 
/ImageRotateNode:
  ros__parameters:
    custom_qos_type: sensor_data
    image_transport: raw
    input_frame_id: ''
    max_angular_rate: 10.0
    output_frame_id: ''
    output_image_size: 2.0
    qos_overrides:
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
      /rotated/image:
        publisher:
          depth: 0
          history: keep_last
          reliability: system_default
      /tf:
        publisher:
          depth: 100
          durability: volatile
          history: keep_last
          reliability: reliable
    rotated:
      image:
        enable_pub_plugins:
        - image_transport/raw
    source_frame_id: ''
    source_x: 0.0
    source_y: -1.0
    source_z: 0.0
    start_type_description_service: true
    target_frame_id: ''
    target_x: 0.0
    target_y: 0.0
    target_z: 1.0
    use_camera_info: true
    use_sim_time: false
```