### PR TITLE
Export image_view symbols on Windows

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -5,6 +5,10 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 20)
 endif()
 
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-image-view.win.patch`, authored in RoboStack by wep21 `<daisuke.nishimatsu1021@gmail.com>`.

Enable `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` for `image_view` on Windows so the shared library exports symbols when building with MSVC-style toolchains.