### PR TITLE
Require Eigen3 in depth_image_proc

### DIFF
--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -13,12 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Eigen3 QUIET)
-if(NOT EIGEN3_FOUND)
-  find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
-  include_directories(include ${EIGEN3_INCLUDE_DIRS})
-endif()
+find_package(Eigen3 REQUIRED)
 
 find_package(OpenCV REQUIRED)
 


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-depth-image-proc.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: depth_image_proc uses Eigen3 in modern ROS 2 builds, and requiring Eigen3 directly avoids the legacy Eigen fallback path that can leave include handling inconsistent for current toolchains.
