### PR TITLE
Export image_publisher symbols on Windows

### DIFF
--- a/image_publisher/CMakeLists.txt
+++ b/image_publisher/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.20)
 project(image_publisher)
 
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 # Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-image-publisher.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: `image_publisher` builds a shared library, and enabling `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` on Windows lets MSVC-style toolchains export symbols without requiring explicit per-symbol annotations. This mirrors the Windows export fixes opened for other `image_pipeline` components.

The original RoboStack patch also defined `_USE_MATH_DEFINES`, but that hunk is no longer needed on current `rolling` because `image_publisher` now uses `<numbers>`.

Related RoboStack upstreaming tracker: https://github.com/RoboStack/robostack.github.io/issues/16
